### PR TITLE
Hook to reactor before starting it

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from tests.adapters.shell.terminal_client_test import telnet_hook_to_reactor, ssh_hook_to_reactor
 from tests.adapters.unified_tests import available_models
 from global_reactor import ThreadedReactor
 
 
 def setup():
-    ThreadedReactor.start_reactor(available_models)
+    ThreadedReactor.start_reactor(available_models, reactor_hook_callbacks=[telnet_hook_to_reactor, ssh_hook_to_reactor])
 
 
 def tearDown():

--- a/tests/global_reactor.py
+++ b/tests/global_reactor.py
@@ -22,8 +22,11 @@ class ThreadedReactor(threading.Thread):
     _threaded_reactor = None
 
     @classmethod
-    def start_reactor(cls, models):
+    def start_reactor(cls, models, reactor_hook_callbacks):
         cls._threaded_reactor = ThreadedReactor()
+
+        for callback in reactor_hook_callbacks:
+            callback(cls._threaded_reactor.reactor)
 
         for specs in models:
 


### PR DESCRIPTION
Doing a listenTCP on the reactor after it is started was flaky at best. It did not work on OS X
and was not best practice. The port would be in the listening state, but the reactor would never
be aware of connections made to the port.

This provides a mechanism for tests to hook onto the reactor being prepared, right before
launching it.