### PR TITLE
Vrrps now has a list of IP Address rather than network

### DIFF
--- a/netman/adapters/switches/brocade.py
+++ b/netman/adapters/switches/brocade.py
@@ -324,8 +324,8 @@ class Brocade(SwitchBase):
             .on_result_matching(".*not between 1 and 254$".format(track_decrement), BadVrrpTracking) \
             .on_any_result(BadVrrpPriorityNumber, 1, 255)
 
-        for i, ip_network in enumerate(ips):
-            self.set('ip-address {}', ip_network.ip).on_any_result(IPNotAvailable, ip_network)
+        for i, ip in enumerate(ips):
+            self.set('ip-address {}', ip).on_any_result(IPNotAvailable, ip)
 
         self.set('hello-interval {}', hello_interval).on_any_result(BadVrrpTimers)
         self.set('dead-interval {}', dead_interval).on_any_result(BadVrrpTimers)
@@ -440,7 +440,7 @@ def add_interface_vlan_data(target_vlan, int_vlan_data):
                 vrrp_group = VrrpGroup(id=int(regex[0]))
                 target_vlan.vrrp_groups.append(vrrp_group)
         elif regex.match("^  ip-address ([^\s]*)", line):
-            vrrp_group.ips.append(IPNetwork(regex[0]))
+            vrrp_group.ips.append(IPAddress(regex[0]))
         elif regex.match("^  backup priority ([^\s]*) track-priority ([^\s]*)", line):
             vrrp_group.priority = int(regex[0])
             vrrp_group.track_decrement = int(regex[1])

--- a/netman/adapters/switches/cisco.py
+++ b/netman/adapters/switches/cisco.py
@@ -340,11 +340,11 @@ class Cisco(SwitchBase):
                 if len(result) > 0:
                     raise BadVrrpTracking()
 
-            for i, ip_network in enumerate(ips):
-                result = self.ssh.do('standby {group_id} ip {ip}{secondary}'.format(group_id=group_id, ip=ip_network.ip,
-                                                                                    secondary=' secondary' if i > 0 else ''))
+            for i, ip in enumerate(ips):
+                result = self.ssh.do('standby {group_id} ip {ip}{secondary}'.format(
+                    group_id=group_id, ip=ip, secondary=' secondary' if i > 0 else ''))
                 if len(result) > 0:
-                    raise IPNotAvailable(ip_network, reason="; ".join(result))
+                    raise IPNotAvailable(ip, reason="; ".join(result))
 
     def remove_vrrp_group(self, vlan_number, group_id):
         vlan = self.get_vlan_interface_data(vlan_number)
@@ -413,7 +413,7 @@ def apply_interface_running_config_data(vlan, data):
             vrrp_info = regex[1].strip()
 
             if regex.match("^ip ([^\s]*).*", vrrp_info):
-                vrrp_group.ips.append(IPNetwork(regex[0]))
+                vrrp_group.ips.append(IPAddress(regex[0]))
             elif regex.match("^timers ([^\s]*) ([^\s]*)", vrrp_info):
                 vrrp_group.hello_interval = int(regex[0])
                 vrrp_group.dead_interval = int(regex[1])

--- a/netman/api/objects/vlan.py
+++ b/netman/api/objects/vlan.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from netaddr import IPNetwork
+from netaddr import IPNetwork, IPAddress
 
 from netman.api.objects import Serializable
 from netman.api.objects.vrrp_group import SerializableVrrpGroup
@@ -41,10 +41,12 @@ class SerializableVlan(Serializable):
         access_groups = serialized.pop('access_groups')
         ips = serialized.pop('ips')
         vrrp_groups = serialized.pop('vrrp_groups')
+        dhcp_relay_servers = serialized.pop('dhcp_relay_servers')
         return Vlan(
             access_group_in=access_groups['in'],
             access_group_out=access_groups['out'],
             ips=[IPNetwork('{address}/{mask}'.format(**ip)) for ip in ips],
             vrrp_groups=[SerializableVrrpGroup.to_core(**group) for group in vrrp_groups],
+            dhcp_relay_servers=[IPAddress(i) for i in dhcp_relay_servers],
             ** serialized
         )

--- a/netman/api/objects/vrrp_group.py
+++ b/netman/api/objects/vrrp_group.py
@@ -23,7 +23,7 @@ class SerializableVrrpGroup(Serializable):
         super(SerializableVrrpGroup, self).__init__(['id', 'ips', 'hello_interval', 'dead_interval', 'priority',
                                                      'track_id', 'track_decrement'])
         self.id = src.id
-        self.ips = sorted([ipn.ip.format() for ipn in src.ips])
+        self.ips = sorted([str(i) for i in src.ips])
         self.priority = src.priority
         self.track_id = src.track_id
         self.track_decrement = src.track_decrement

--- a/netman/api/objects/vrrp_group.py
+++ b/netman/api/objects/vrrp_group.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from netaddr import IPNetwork
+from netaddr import IPAddress
 
 from netman.api.objects import Serializable
 from netman.core.objects.vrrp_group import VrrpGroup
@@ -34,6 +34,6 @@ class SerializableVrrpGroup(Serializable):
     def to_core(cls, **serialized):
         ips = serialized.pop('ips')
         return VrrpGroup(
-            ips=[IPNetwork(ip) for ip in ips],
+            ips=[IPAddress(ip) for ip in ips],
             ** serialized
         )

--- a/netman/api/validators.py
+++ b/netman/api/validators.py
@@ -17,7 +17,7 @@ import json
 import logging
 import re
 
-from netaddr import IPNetwork, AddrFormatError
+from netaddr import IPNetwork, AddrFormatError, IPAddress
 from flask import request
 
 from netman.api.api_utils import BadRequest, MultiContext
@@ -282,7 +282,7 @@ def is_vrrp_group(data, **_):
 
     return dict(
         group_id=data.pop('id'),
-        ips=[is_ip_network(x)['validated_ip_network'] for x in data.pop('ips', [])],
+        ips=[validate_ip_address(i) for i in data.pop('ips', [])],
         **data
     )
 
@@ -358,6 +358,13 @@ def is_dict_with(**fields):
         return result
 
     return m
+
+
+def validate_ip_address(data):
+    try:
+        return IPAddress(data)
+    except:
+        raise BadRequest("Incorrect IP Address: \"{}\", should be x.x.x.x".format(data))
 
 
 def optional(sub_validator):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import logging
+from netaddr import IPAddress, IPNetwork
 
 from tests.adapters.shell.terminal_client_test import telnet_hook_to_reactor, ssh_hook_to_reactor
 from tests.adapters.unified_tests import available_models
@@ -23,3 +25,21 @@ def setup():
 
 def tearDown():
     ThreadedReactor.stop_reactor()
+
+
+class ExactIpNetwork(object):
+    def __init__(self, ip, mask):
+        self.ip = IPAddress(ip)
+        self.mask = mask
+
+    def __eq__(self, other):
+        if not isinstance(other, IPNetwork):
+            logging.error("{} is not an IPNetwork object".format(repr(other)))
+            return False
+        result = other.ip == self.ip and other.prefixlen == self.mask
+        if not result:
+            logging.error("Expected {}/{} and got {}/{}".format(self.ip, self.mask, other.ip, other.prefixlen))
+        return result
+
+    def __repr__(self):
+        return "{}/{}".format(self.ip, self.mask)

--- a/tests/adapters/switches/brocade_test.py
+++ b/tests/adapters/switches/brocade_test.py
@@ -141,15 +141,15 @@ class BrocadeTest(unittest.TestCase):
 
         vrrp_group1, vrrp_group2 = vlan201.vrrp_groups
         assert_that(len(vrrp_group1.ips), equal_to(1))
-        assert_that(str(vrrp_group1.ips[0].ip), equal_to('1.1.1.2'))
+        assert_that(vrrp_group1.ips[0], equal_to(IPAddress('1.1.1.2')))
         assert_that(vrrp_group1.hello_interval, equal_to(5))
         assert_that(vrrp_group1.dead_interval, equal_to(15))
         assert_that(vrrp_group1.priority, equal_to(110))
         assert_that(vrrp_group1.track_id, equal_to('1/1'))
         assert_that(vrrp_group1.track_decrement, equal_to(50))
         assert_that(len(vrrp_group2.ips), equal_to(2))
-        assert_that(str(vrrp_group2.ips[0].ip), equal_to('1.1.1.3'))
-        assert_that(str(vrrp_group2.ips[1].ip), equal_to('1.1.1.4'))
+        assert_that(vrrp_group2.ips[0], equal_to(IPAddress('1.1.1.3')))
+        assert_that(vrrp_group2.ips[1], equal_to(IPAddress('1.1.1.4')))
         assert_that(vrrp_group2.hello_interval, equal_to(5))
         assert_that(vrrp_group2.dead_interval, equal_to(15))
         assert_that(vrrp_group2.priority, equal_to(110))
@@ -1407,7 +1407,7 @@ class BrocadeTest(unittest.TestCase):
         self.mocked_ssh_client.should_receive("do").with_args("exit").and_return([]).twice().ordered().ordered()
         self.mocked_ssh_client.should_receive("do").with_args("write memory").and_return([]).once().ordered()
 
-        self.switch.add_vrrp_group(1234, 1, ips=[IPNetwork("1.2.3.4")], priority=110, hello_interval=5, dead_interval=15,
+        self.switch.add_vrrp_group(1234, 1, ips=[IPAddress("1.2.3.4")], priority=110, hello_interval=5, dead_interval=15,
                                    track_id="1/1", track_decrement=50)
 
     def test_add_vrrp_success_multiple_ip(self):
@@ -1440,7 +1440,7 @@ class BrocadeTest(unittest.TestCase):
         self.mocked_ssh_client.should_receive("do").with_args("exit").and_return([]).twice().ordered().ordered()
         self.mocked_ssh_client.should_receive("do").with_args("write memory").and_return([]).once().ordered()
 
-        self.switch.add_vrrp_group(1234, 1, ips=[IPNetwork("1.2.3.4"), IPNetwork("1.2.3.5")], priority=110,
+        self.switch.add_vrrp_group(1234, 1, ips=[IPAddress("1.2.3.4"), IPAddress("1.2.3.5")], priority=110,
                                    hello_interval=5, dead_interval=15, track_id="1/1", track_decrement=50)
 
     def test_add_vrrp_from_unknown_vlan(self):
@@ -1449,7 +1449,7 @@ class BrocadeTest(unittest.TestCase):
         self.mocked_ssh_client.should_receive("do").with_args("show running-config vlan | begin vlan 1234").once().ordered().and_return([])
 
         with self.assertRaises(UnknownVlan) as expect:
-            self.switch.add_vrrp_group(1234, 1, ips=[IPNetwork("1.2.3.4")], priority=110, hello_interval=5, dead_interval=15,
+            self.switch.add_vrrp_group(1234, 1, ips=[IPAddress("1.2.3.4")], priority=110, hello_interval=5, dead_interval=15,
                                        track_id="1/1", track_decrement=50)
 
         assert_that(str(expect.exception), equal_to("Vlan 1234 not found"))
@@ -1478,7 +1478,7 @@ class BrocadeTest(unittest.TestCase):
         ])
 
         with self.assertRaises(VrrpAlreadyExistsForVlan) as expect:
-            self.switch.add_vrrp_group(1234, 1, ips=[IPNetwork("1.2.3.4")], priority=110, hello_interval=5, dead_interval=15,
+            self.switch.add_vrrp_group(1234, 1, ips=[IPAddress("1.2.3.4")], priority=110, hello_interval=5, dead_interval=15,
                                        track_id="1/1", track_decrement=50)
 
         assert_that(str(expect.exception), equal_to("Vrrp group 1 is already in use on vlan 1234"))
@@ -1520,7 +1520,7 @@ class BrocadeTest(unittest.TestCase):
         self.mocked_ssh_client.should_receive("do").with_args("exit").and_return([]).twice().ordered().ordered()
         self.mocked_ssh_client.should_receive("do").with_args("write memory").and_return([]).once().ordered()
 
-        self.switch.add_vrrp_group(1234, 2, ips=[IPNetwork("1.2.3.5")], priority=110, hello_interval=5, dead_interval=15,
+        self.switch.add_vrrp_group(1234, 2, ips=[IPAddress("1.2.3.5")], priority=110, hello_interval=5, dead_interval=15,
                                    track_id="1/1", track_decrement=50)
 
     def test_add_vrrp_with_out_of_range_group_id(self):
@@ -1547,7 +1547,7 @@ class BrocadeTest(unittest.TestCase):
         self.mocked_ssh_client.should_receive("do").with_args("exit").and_return([]).twice().ordered().ordered()
 
         with self.assertRaises(BadVrrpGroupNumber) as expect:
-            self.switch.add_vrrp_group(1234, 256, ips=[IPNetwork("1.2.3.4")], priority=110, hello_interval=5, dead_interval=15,
+            self.switch.add_vrrp_group(1234, 256, ips=[IPAddress("1.2.3.4")], priority=110, hello_interval=5, dead_interval=15,
                                        track_id="1/1", track_decrement=50)
 
         assert_that(str(expect.exception), equal_to("VRRP group number is invalid, must be contained between 1 and 255"))
@@ -1579,7 +1579,7 @@ class BrocadeTest(unittest.TestCase):
         self.mocked_ssh_client.should_receive("do").with_args("exit").and_return([]).times(3).ordered().ordered().ordered()
 
         with self.assertRaises(BadVrrpTimers) as expect:
-            self.switch.add_vrrp_group(1234, 1, ips=[IPNetwork("1.2.3.4")], priority=110, hello_interval=100, dead_interval=15,
+            self.switch.add_vrrp_group(1234, 1, ips=[IPAddress("1.2.3.4")], priority=110, hello_interval=100, dead_interval=15,
                                        track_id="1/1", track_decrement=50)
 
         assert_that(str(expect.exception), equal_to("VRRP timers values are invalid"))
@@ -1612,7 +1612,7 @@ class BrocadeTest(unittest.TestCase):
         self.mocked_ssh_client.should_receive("do").with_args("exit").and_return([]).times(3).ordered().ordered().ordered()
 
         with self.assertRaises(BadVrrpTimers) as expect:
-            self.switch.add_vrrp_group(1234, 1, ips=[IPNetwork("1.2.3.4")], priority=110, hello_interval=5, dead_interval=100,
+            self.switch.add_vrrp_group(1234, 1, ips=[IPAddress("1.2.3.4")], priority=110, hello_interval=5, dead_interval=100,
                                        track_id="1/1", track_decrement=50)
 
         assert_that(str(expect.exception), equal_to("VRRP timers values are invalid"))
@@ -1642,7 +1642,7 @@ class BrocadeTest(unittest.TestCase):
         self.mocked_ssh_client.should_receive("do").with_args("exit").and_return([]).times(3).ordered().ordered().ordered()
 
         with self.assertRaises(BadVrrpPriorityNumber) as expect:
-            self.switch.add_vrrp_group(1234, 1, ips=[IPNetwork("1.2.3.4")], priority=256, hello_interval=5, dead_interval=100,
+            self.switch.add_vrrp_group(1234, 1, ips=[IPAddress("1.2.3.4")], priority=256, hello_interval=5, dead_interval=100,
                                        track_id="1/1", track_decrement=50)
 
         assert_that(str(expect.exception), equal_to("VRRP priority value is invalid, must be contained between 1 and 255"))
@@ -1672,7 +1672,7 @@ class BrocadeTest(unittest.TestCase):
         self.mocked_ssh_client.should_receive("do").with_args("exit").and_return([]).times(3).ordered().ordered().ordered()
 
         with self.assertRaises(BadVrrpPriorityNumber) as expect:
-            self.switch.add_vrrp_group(1234, 1, ips=[IPNetwork("1.2.3.4")], priority='testvalue', hello_interval=5, dead_interval=15,
+            self.switch.add_vrrp_group(1234, 1, ips=[IPAddress("1.2.3.4")], priority='testvalue', hello_interval=5, dead_interval=15,
                                        track_id="1/1", track_decrement=50)
 
         assert_that(str(expect.exception), equal_to("VRRP priority value is invalid, must be contained between 1 and 255"))
@@ -1702,7 +1702,7 @@ class BrocadeTest(unittest.TestCase):
         self.mocked_ssh_client.should_receive("do").with_args("exit").and_return([]).times(3).ordered().ordered().ordered()
 
         with self.assertRaises(BadVrrpTracking) as expect:
-            self.switch.add_vrrp_group(1234, 1, ips=[IPNetwork("1.2.3.4")], priority=110, hello_interval=5, dead_interval=15,
+            self.switch.add_vrrp_group(1234, 1, ips=[IPAddress("1.2.3.4")], priority=110, hello_interval=5, dead_interval=15,
                                        track_id="1/1", track_decrement=255)
 
         assert_that(str(expect.exception), equal_to("VRRP tracking values are invalid"))
@@ -1732,7 +1732,7 @@ class BrocadeTest(unittest.TestCase):
         self.mocked_ssh_client.should_receive("do").with_args("exit").and_return([]).times(3).ordered().ordered().ordered()
 
         with self.assertRaises(BadVrrpTracking) as expect:
-            self.switch.add_vrrp_group(1234, 1, ips=[IPNetwork("1.2.3.4")], priority=110, hello_interval=5, dead_interval=15,
+            self.switch.add_vrrp_group(1234, 1, ips=[IPAddress("1.2.3.4")], priority=110, hello_interval=5, dead_interval=15,
                                        track_id="1/1", track_decrement='testvalue')
 
         assert_that(str(expect.exception), equal_to("VRRP tracking values are invalid"))
@@ -1759,7 +1759,7 @@ class BrocadeTest(unittest.TestCase):
         self.mocked_ssh_client.should_receive("do").with_args("exit").and_return([]).times(2).ordered().ordered()
 
         with self.assertRaises(NoIpOnVlanForVrrp) as expect:
-            self.switch.add_vrrp_group(1234, 1, ips=[IPNetwork("1.2.3.4")], priority=110, hello_interval=5, dead_interval=100,
+            self.switch.add_vrrp_group(1234, 1, ips=[IPAddress("1.2.3.4")], priority=110, hello_interval=5, dead_interval=100,
                                        track_id="1/1", track_decrement=50)
 
         assert_that(str(expect.exception), equal_to("Vlan 1234 needs an IP before configuring VRRP"))
@@ -1794,7 +1794,7 @@ class BrocadeTest(unittest.TestCase):
         self.mocked_ssh_client.should_receive("do").with_args("exit").and_return([]).times(3).ordered().ordered().ordered()
 
         with self.assertRaises(BadVrrpTracking) as expect:
-            self.switch.add_vrrp_group(1234, 1, ips=[IPNetwork("1.2.3.4")], priority=110, hello_interval=5, dead_interval=15,
+            self.switch.add_vrrp_group(1234, 1, ips=[IPAddress("1.2.3.4")], priority=110, hello_interval=5, dead_interval=15,
                                        track_id="not_an_interface", track_decrement=50)
 
         assert_that(str(expect.exception), equal_to("VRRP tracking values are invalid"))

--- a/tests/adapters/switches/cisco_test.py
+++ b/tests/adapters/switches/cisco_test.py
@@ -173,9 +173,9 @@ class CiscoTest(unittest.TestCase):
 
         v3_vrrp = v3.vrrp_groups[0]
         assert_that(len(v3_vrrp.ips), equal_to(3))
-        assert_that(str(v3_vrrp.ips[0].ip), equal_to('1.1.1.2'))
-        assert_that(str(v3_vrrp.ips[1].ip), equal_to('2.1.1.2'))
-        assert_that(str(v3_vrrp.ips[2].ip), equal_to('3.1.1.2'))
+        assert_that(v3_vrrp.ips[0], equal_to(IPAddress('1.1.1.2')))
+        assert_that(v3_vrrp.ips[1], equal_to(IPAddress('2.1.1.2')))
+        assert_that(v3_vrrp.ips[2], equal_to(IPAddress('3.1.1.2')))
         assert_that(v3_vrrp.hello_interval, equal_to(5))
         assert_that(v3_vrrp.dead_interval, equal_to(15))
         assert_that(v3_vrrp.priority, equal_to(110))
@@ -1687,7 +1687,7 @@ class CiscoTest(unittest.TestCase):
         self.mocked_ssh_client.should_receive("do").with_args("exit").and_return([]).twice().ordered().ordered()
         self.mocked_ssh_client.should_receive("do").with_args("write memory").and_return([]).once().ordered()
 
-        self.switch.add_vrrp_group(1234, 1, ips=[IPNetwork("1.2.3.4")], priority=110, hello_interval=5, dead_interval=15,
+        self.switch.add_vrrp_group(1234, 1, ips=[IPAddress("1.2.3.4")], priority=110, hello_interval=5, dead_interval=15,
                                    track_id=101, track_decrement=50)
 
     def test_add_vrrp_success_multiple_ip(self):
@@ -1717,7 +1717,7 @@ class CiscoTest(unittest.TestCase):
         self.mocked_ssh_client.should_receive("do").with_args("exit").and_return([]).twice().ordered().ordered()
         self.mocked_ssh_client.should_receive("do").with_args("write memory").and_return([]).once().ordered()
 
-        self.switch.add_vrrp_group(1234, 1, ips=[IPNetwork("1.2.3.4"), IPNetwork("5.6.7.8")], priority=110,
+        self.switch.add_vrrp_group(1234, 1, ips=[IPAddress("1.2.3.4"), IPAddress("5.6.7.8")], priority=110,
                                    hello_interval=5, dead_interval=15, track_id=101,
                                    track_decrement=50)
 
@@ -1736,7 +1736,7 @@ class CiscoTest(unittest.TestCase):
         ])
 
         with self.assertRaises(UnknownVlan) as expect:
-            self.switch.add_vrrp_group(1234, 1, ips=[IPNetwork("1.2.3.4")])
+            self.switch.add_vrrp_group(1234, 1, ips=[IPAddress("1.2.3.4")])
 
         assert_that(str(expect.exception), equal_to("Vlan 1234 not found"))
 
@@ -1755,7 +1755,7 @@ class CiscoTest(unittest.TestCase):
         ])
 
         with self.assertRaises(VrrpAlreadyExistsForVlan) as expect:
-            self.switch.add_vrrp_group(1234, 1, ips=[IPNetwork("1.2.3.4")], priority=90)
+            self.switch.add_vrrp_group(1234, 1, ips=[IPAddress("1.2.3.4")], priority=90)
 
         assert_that(str(expect.exception), equal_to("Vrrp group 1 is already in use on vlan 1234"))
 
@@ -1786,13 +1786,13 @@ class CiscoTest(unittest.TestCase):
         self.mocked_ssh_client.should_receive("do").with_args("exit").and_return([]).twice().ordered().ordered()
         self.mocked_ssh_client.should_receive("do").with_args("write memory").and_return([]).once().ordered()
 
-        self.switch.add_vrrp_group(1234, 2, ips=[IPNetwork("1.2.3.5")], priority=90)
+        self.switch.add_vrrp_group(1234, 2, ips=[IPAddress("1.2.3.5")], priority=90)
 
     def test_add_vrrp_with_out_of_range_group_id(self):
         self.command_setup()
 
         with self.assertRaises(BadVrrpGroupNumber) as expect:
-            self.switch.add_vrrp_group(1234, 0, ips=[IPNetwork("1.2.3.4")], priority=255)
+            self.switch.add_vrrp_group(1234, 0, ips=[IPAddress("1.2.3.4")], priority=255)
 
         assert_that(str(expect.exception), equal_to("VRRP group number is invalid, must be contained between 1 and 255"))
 
@@ -1819,7 +1819,7 @@ class CiscoTest(unittest.TestCase):
         self.mocked_ssh_client.should_receive("do").with_args("exit").and_return([]).twice().ordered().ordered()
 
         with self.assertRaises(BadVrrpPriorityNumber) as expect:
-            self.switch.add_vrrp_group(1234, 1, ips=[IPNetwork("1.2.3.4")], priority=256)
+            self.switch.add_vrrp_group(1234, 1, ips=[IPAddress("1.2.3.4")], priority=256)
 
         assert_that(str(expect.exception), equal_to("VRRP priority value is invalid, must be contained between 1 and 255"))
 
@@ -1848,7 +1848,7 @@ class CiscoTest(unittest.TestCase):
         self.mocked_ssh_client.should_receive("do").with_args("exit").and_return([]).twice().ordered().ordered()
 
         with self.assertRaises(BadVrrpTimers) as expect:
-            self.switch.add_vrrp_group(1234, 1, ips=[IPNetwork("1.2.3.4")], hello_interval=-1, dead_interval=-1)
+            self.switch.add_vrrp_group(1234, 1, ips=[IPAddress("1.2.3.4")], hello_interval=-1, dead_interval=-1)
 
         assert_that(str(expect.exception), equal_to("VRRP timers values are invalid"))
 
@@ -1879,7 +1879,7 @@ class CiscoTest(unittest.TestCase):
         self.mocked_ssh_client.should_receive("do").with_args("exit").and_return([]).twice().ordered().ordered()
 
         with self.assertRaises(BadVrrpTracking) as expect:
-            self.switch.add_vrrp_group(1234, 1, ips=[IPNetwork("1.2.3.4")], track_id='SOMETHING', track_decrement='VALUE')
+            self.switch.add_vrrp_group(1234, 1, ips=[IPAddress("1.2.3.4")], track_id='SOMETHING', track_decrement='VALUE')
 
         assert_that(str(expect.exception), equal_to("VRRP tracking values are invalid"))
 

--- a/tests/adapters/switches/remote_test.py
+++ b/tests/adapters/switches/remote_test.py
@@ -18,7 +18,7 @@ import unittest
 from hamcrest import assert_that, equal_to, is_, instance_of
 import mock
 from ncclient.operations import RPCError
-from netaddr import IPNetwork
+from netaddr import IPNetwork, IPAddress
 from flexmock import flexmock, flexmock_teardown
 
 from tests.api import open_fixture
@@ -901,7 +901,7 @@ class RemoteSwitchTest(unittest.TestCase):
             headers=self.headers,
             data=JsonData(id=1,
                           priority=2,
-                          ips=['1.2.3.4/32'],
+                          ips=['1.2.3.4'],
                           hello_interval=5,
                           dead_interval=15,
                           track_id="101",
@@ -911,7 +911,7 @@ class RemoteSwitchTest(unittest.TestCase):
                 content='',
                 status_code=201))
 
-        self.switch.add_vrrp_group(2000, group_id=1, priority=2, ips=[IPNetwork('1.2.3.4')], hello_interval=5,
+        self.switch.add_vrrp_group(2000, group_id=1, priority=2, ips=[IPAddress('1.2.3.4')], hello_interval=5,
                                    dead_interval=15, track_id='101', track_decrement=50)
 
     def test_remove_vrrp_group(self):

--- a/tests/api/switch_api_test.py
+++ b/tests/api/switch_api_test.py
@@ -18,6 +18,7 @@ from netaddr import IPNetwork
 from netaddr.ip import IPAddress
 
 from netman.core.objects.vrrp_group import VrrpGroup
+from tests import ExactIpNetwork
 from tests.api import matches_fixture
 from tests.api.base_api_test import BaseApiTest
 from netman.api.api_utils import RegexConverter
@@ -526,7 +527,7 @@ class SwitchApiTest(BaseApiTest):
     def test_add_ip_json(self):
         self.switch_factory.should_receive('get_switch').with_args('my.switch').and_return(self.switch_mock).once().ordered()
         self.switch_mock.should_receive('connect').once().ordered()
-        self.switch_mock.should_receive('add_ip_to_vlan').with_args(2500, IPNetwork("1.2.3.4/25")).once().ordered()
+        self.switch_mock.should_receive('add_ip_to_vlan').with_args(2500, ExactIpNetwork("1.2.3.4", 25)).once().ordered()
         self.switch_mock.should_receive('disconnect').once().ordered()
 
         result, code = self.post("/switches/my.switch/vlans/2500/ips", fixture="post_switch_hostname_vlans_vlanid_ips.json")
@@ -536,7 +537,7 @@ class SwitchApiTest(BaseApiTest):
     def test_add_ip_ipnetwork(self):
         self.switch_factory.should_receive('get_switch').with_args('my.switch').and_return(self.switch_mock).once().ordered()
         self.switch_mock.should_receive('connect').once().ordered()
-        self.switch_mock.should_receive('add_ip_to_vlan').with_args(2500, IPNetwork("1.2.3.4/25")).once().ordered()
+        self.switch_mock.should_receive('add_ip_to_vlan').with_args(2500, ExactIpNetwork("1.2.3.4", 25)).once().ordered()
         self.switch_mock.should_receive('disconnect').once().ordered()
 
         result, code = self.post("/switches/my.switch/vlans/2500/ips", fixture="post_switch_hostname_vlans_vlanid_ips.txt")
@@ -573,7 +574,7 @@ class SwitchApiTest(BaseApiTest):
     def test_add_ip_not_available(self):
         self.switch_factory.should_receive('get_switch').with_args('my.switch').and_return(self.switch_mock).once().ordered()
         self.switch_mock.should_receive('connect').once().ordered()
-        self.switch_mock.should_receive('add_ip_to_vlan').with_args(2500, IPNetwork("1.2.3.4/25")).once().ordered()\
+        self.switch_mock.should_receive('add_ip_to_vlan').with_args(2500, ExactIpNetwork("1.2.3.4", 25)).once().ordered()\
             .and_raise(IPNotAvailable(IPNetwork("1.2.3.4/25")))
         self.switch_mock.should_receive('disconnect').once().ordered()
 
@@ -585,7 +586,7 @@ class SwitchApiTest(BaseApiTest):
     def test_add_ip_unknown_vlan(self):
         self.switch_factory.should_receive('get_switch').with_args('my.switch').and_return(self.switch_mock).once().ordered()
         self.switch_mock.should_receive('connect').once().ordered()
-        self.switch_mock.should_receive('add_ip_to_vlan').with_args(2500, IPNetwork("1.2.3.4/25")).once().ordered()\
+        self.switch_mock.should_receive('add_ip_to_vlan').with_args(2500, ExactIpNetwork("1.2.3.4", 25)).once().ordered()\
             .and_raise(UnknownVlan('2500'))
         self.switch_mock.should_receive('disconnect').once().ordered()
 
@@ -597,7 +598,7 @@ class SwitchApiTest(BaseApiTest):
     def test_remove_ip(self):
         self.switch_factory.should_receive('get_switch').with_args('my.switch').and_return(self.switch_mock).once().ordered()
         self.switch_mock.should_receive('connect').once().ordered()
-        self.switch_mock.should_receive('remove_ip_from_vlan').with_args(2500, IPNetwork("1.2.3.4/25")).once().ordered()
+        self.switch_mock.should_receive('remove_ip_from_vlan').with_args(2500, ExactIpNetwork("1.2.3.4", 25)).once().ordered()
         self.switch_mock.should_receive('disconnect').once().ordered()
 
         result, code = self.delete("/switches/my.switch/vlans/2500/ips/1.2.3.4/25")
@@ -607,7 +608,7 @@ class SwitchApiTest(BaseApiTest):
     def test_remove_ip_unknown_vlan(self):
         self.switch_factory.should_receive('get_switch').with_args('my.switch').and_return(self.switch_mock).once().ordered()
         self.switch_mock.should_receive('connect').once().ordered()
-        self.switch_mock.should_receive('remove_ip_from_vlan').with_args(2500, IPNetwork("1.2.3.4/25")).once().ordered()\
+        self.switch_mock.should_receive('remove_ip_from_vlan').with_args(2500, ExactIpNetwork("1.2.3.4", 25)).once().ordered()\
             .and_raise(UnknownVlan('2500'))
         self.switch_mock.should_receive('disconnect').once().ordered()
 
@@ -619,7 +620,7 @@ class SwitchApiTest(BaseApiTest):
     def test_remove_unknown_ip(self):
         self.switch_factory.should_receive('get_switch').with_args('my.switch').and_return(self.switch_mock).once().ordered()
         self.switch_mock.should_receive('connect').once().ordered()
-        self.switch_mock.should_receive('remove_ip_from_vlan').with_args(2500, IPNetwork("1.2.3.4/25")).once().ordered()\
+        self.switch_mock.should_receive('remove_ip_from_vlan').with_args(2500, ExactIpNetwork("1.2.3.4", 25)).once().ordered()\
             .and_raise(UnknownIP(IPNetwork("1.2.3.4/25")))
         self.switch_mock.should_receive('disconnect').once().ordered()
 


### PR DESCRIPTION
The list was indeed IP so the correct data type is now used
Comparing IP Network only checks for the subnet/mask and not the IP