### PR TITLE
Cached switch adapter support.

### DIFF
--- a/netman/adapters/switches/cached.py
+++ b/netman/adapters/switches/cached.py
@@ -1,0 +1,319 @@
+# Copyright 2015 Internap.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import OrderedDict
+
+from netman.core.objects import port_modes
+from netman.core.objects.bond import Bond
+from netman.core.objects.interface import Interface
+from netman.core.objects.switch_base import SwitchBase
+from netman.core.objects.vlan import Vlan
+from netman.core.objects.vrrp_group import VrrpGroup
+
+
+__all__ = ['CachedSwitch']
+
+
+class Cache():
+    object_type = None
+    object_key = None
+    object_extra = {}
+
+    def __init__(self, *args, **kwargs):
+        self.need_refresh = set()
+        self.dict = OrderedDict(*args, **kwargs)
+
+    def __getitem__(self, item):
+        try:
+            return self.dict[item]
+        except KeyError:
+            # don't create the item, just act as it is present
+            self.need_refresh.add(item)
+            params = {self.object_key: item}
+            params.update({k:(v() if callable(v) else v)
+                           for k, v in self.object_extra.iteritems()})
+            return self.object_type(**params)
+
+    def __setitem__(self, key, value):
+        if not self.dict:
+            self.need_refresh.add(None)
+        self.dict[key] = value
+        try:
+            self.need_refresh.remove(key)
+        except KeyError:
+            pass
+
+    def __contains__(self, item):
+        return item in self.dict
+
+    def __len__(self):
+        return len(self.dict)
+
+    def __delitem__(self, key):
+        del self.dict[key]
+        try:
+            self.need_refresh.remove(key)
+        except KeyError:
+            pass
+
+    def values(self):
+        return self.dict.values()
+
+
+class VlanCache(Cache):
+    object_type = Vlan
+    object_key = 'number'
+
+
+class InterfaceCache(Cache):
+    object_type = Interface
+    object_key = 'name'
+
+
+class BondCache(Cache):
+    object_type = Bond
+    object_key = 'number'
+    object_extra = dict(interface=Interface)
+
+
+class CachedSwitch(SwitchBase):
+    def __init__(self, real_switch):
+        super(CachedSwitch, self).__init__(real_switch.switch_descriptor)
+        self.real_switch = real_switch
+        self.vlans_cache = VlanCache()
+        self.interfaces_cache = InterfaceCache()
+        self.bonds_cache = BondCache()
+
+    def connect(self):
+        return self.real_switch.connect()
+
+    def disconnect(self):
+        return self.real_switch.disconnect()
+
+    def start_transaction(self):
+        return self.real_switch.start_transaction()
+
+    def commit_transaction(self):
+        return self.real_switch.commit_transaction()
+
+    def rollback_transaction(self):
+        return self.real_switch.rollback_transaction()
+
+    def end_transaction(self):
+        return self.real_switch.end_transaction()
+
+    def get_vlans(self):
+        if not self.vlans_cache or self.vlans_cache.need_refresh:
+            self.vlans_cache = VlanCache(
+                ((vlan.number, vlan) for vlan in self.real_switch.get_vlans()))
+        return self.vlans_cache.values()
+
+    def get_interfaces(self):
+        if not self.interfaces_cache or self.interfaces_cache.need_refresh:
+            self.interfaces_cache = InterfaceCache(
+                ((interface.name, interface)
+                 for interface in self.real_switch.get_interfaces()))
+        return self.interfaces_cache.values()
+
+    def get_bond(self, number):
+        if number not in self.bonds_cache\
+                or number in self.bonds_cache.need_refresh:
+            self.bonds_cache[number] = self.real_switch.get_bond(number)
+        return self.bonds_cache[number]
+
+    def get_bonds(self):
+        if not self.bonds_cache or self.bonds_cache.need_refresh:
+            self.bonds_cache = BondCache(
+                ((bond.number, bond) for bond in self.real_switch.get_bonds()))
+        return self.bonds_cache.values()
+
+    def add_vlan(self, number, name=None):
+        result = self.real_switch.add_vlan(number, name)
+        self.vlans_cache[number] = Vlan(number, name=name)
+        return result
+
+    def remove_vlan(self, number):
+        self.real_switch.remove_vlan(number)
+        del self.vlans_cache[number]
+
+    def set_vlan_access_group(self, vlan_number, direction, name):
+        self.real_switch.set_vlan_access_group(vlan_number, direction, name)
+        self.vlans_cache[vlan_number].access_groups[direction] = name
+
+    def remove_vlan_access_group(self, vlan_number, direction):
+        self.real_switch.remove_vlan_access_group(vlan_number, direction)
+        self.vlans_cache[vlan_number].access_groups[direction] = None
+
+    def add_ip_to_vlan(self, vlan_number, ip_network):
+        self.real_switch.add_ip_to_vlan(vlan_number, ip_network)
+        self.vlans_cache[vlan_number].ips.append(ip_network)
+
+    def remove_ip_from_vlan(self, vlan_number, ip_network):
+        self.real_switch.remove_ip_from_vlan(vlan_number, ip_network)
+        self.vlans_cache[vlan_number].ips.remove(
+            next(net for net in self.vlans_cache[vlan_number].ips
+                 if str(net) == str(ip_network)))
+
+    def set_vlan_vrf(self, vlan_number, vrf_name):
+        self.real_switch.set_vlan_vrf(vlan_number, vrf_name)
+        self.vlans_cache[vlan_number].vrf_forwarding = vrf_name
+
+    def remove_vlan_vrf(self, vlan_number):
+        self.real_switch.remove_vlan_vrf(vlan_number)
+        self.vlans_cache[vlan_number].vrf_forwarding = None
+
+    def set_access_mode(self, interface_id):
+        self.real_switch.set_access_mode(interface_id)
+        self.interfaces_cache[interface_id].port_mode = port_modes.ACCESS
+
+    def set_trunk_mode(self, interface_id):
+        self.real_switch.set_trunk_mode(interface_id)
+        self.interfaces_cache[interface_id].port_mode = port_modes.TRUNK
+
+    def set_bond_access_mode(self, bond_number):
+        self.real_switch.set_bond_access_mode(bond_number)
+        self.bonds_cache[bond_number].interface.port_mode = port_modes.ACCESS
+
+    def set_bond_trunk_mode(self, bond_number):
+        self.real_switch.set_bond_trunk_mode(bond_number)
+        self.bonds_cache[bond_number].interface.port_mode = port_modes.TRUNK
+
+    def set_access_vlan(self, interface_id, vlan):
+        self.real_switch.set_access_vlan(interface_id, vlan)
+        self.interfaces_cache[interface_id].access_vlan = vlan
+
+    def remove_access_vlan(self, interface_id):
+        self.real_switch.remove_access_vlan(interface_id)
+        self.interfaces_cache[interface_id].access_vlan = None
+
+    def configure_native_vlan(self, interface_id, vlan):
+        self.real_switch.configure_native_vlan(interface_id, vlan)
+        self.interfaces_cache[interface_id].trunk_native_vlan = vlan
+
+    def remove_native_vlan(self, interface_id):
+        self.real_switch.remove_native_vlan(interface_id)
+        self.interfaces_cache[interface_id].trunk_native_vlan = None
+
+    def configure_bond_native_vlan(self, bond_number, vlan):
+        self.real_switch.configure_bond_native_vlan(bond_number, vlan)
+        self.bonds_cache[bond_number].interface.trunk_native_vlan = vlan
+
+    def remove_bond_native_vlan(self, bond_number):
+        self.real_switch.remove_bond_native_vlan(bond_number)
+        self.bonds_cache[bond_number].interface.trunk_native_vlan = None
+
+    def add_trunk_vlan(self, interface_id, vlan):
+        self.real_switch.add_trunk_vlan(interface_id, vlan)
+        self.interfaces_cache[interface_id].trunk_vlans.append(vlan)
+
+    def remove_trunk_vlan(self, interface_id, vlan):
+        self.real_switch.remove_trunk_vlan(interface_id, vlan)
+        self.interfaces_cache[interface_id].trunk_vlans.remove(vlan)
+
+    def add_bond_trunk_vlan(self, bond_number, vlan):
+        self.real_switch.add_bond_trunk_vlan(bond_number, vlan)
+        self.bonds_cache[bond_number].interface.trunk_vlans.append(vlan)
+
+    def remove_bond_trunk_vlan(self, bond_number, vlan):
+        self.real_switch.remove_bond_trunk_vlan(bond_number, vlan)
+        self.bonds_cache[bond_number].interface.trunk_vlans.remove(vlan)
+
+    def set_interface_description(self, interface_id, description):
+        # No cache to update
+        self.real_switch.set_interface_description(interface_id, description)
+
+    def remove_interface_description(self, interface_id):
+        # No cache to update
+        self.real_switch.remove_interface_description(interface_id)
+
+    def set_bond_description(self, bond_number, description):
+        # No cache to update
+        self.real_switch.set_bond_description(bond_number, description)
+
+    def remove_bond_description(self, bond_number):
+        # No cache to update
+        self.real_switch.remove_bond_description(bond_number)
+
+    def edit_interface_spanning_tree(self, interface_id, edge=None):
+        # No cache to update
+        self.real_switch.edit_interface_spanning_tree(interface_id, edge)
+
+    def openup_interface(self, interface_id):
+        self.real_switch.openup_interface(interface_id)
+        self.interfaces_cache[interface_id].shutdown = False
+
+    def shutdown_interface(self, interface_id):
+        self.real_switch.shutdown_interface(interface_id)
+        self.interfaces_cache[interface_id].shutdown = True
+
+    def add_bond(self, number):
+        self.real_switch.add_bond(number)
+        self.bonds_cache[number] = Bond(number=number)
+
+    def remove_bond(self, number):
+        self.real_switch.remove_bond(number)
+        del self.bonds_cache[number]
+
+    def add_interface_to_bond(self, interface, bond_number):
+        self.real_switch.add_interface_to_bond(interface, bond_number)
+        self.bonds_cache[bond_number].members.append(interface)
+        self.interfaces_cache[interface].bond_master = bond_number
+
+    def remove_interface_from_bond(self, interface):
+        self.real_switch.remove_interface_from_bond(interface)
+        self.interfaces_cache[interface].bond_master = None
+        for bond in self.bonds_cache.values():
+            try:
+                bond.members.remove(interface)
+            except ValueError:
+                pass
+
+    def set_bond_link_speed(self, number, speed):
+        self.real_switch.set_bond_link_speed(number, speed)
+        self.bonds_cache[number].link_speed = speed
+
+    def edit_bond_spanning_tree(self, number, edge=None):
+        self.real_switch.edit_bond_spanning_tree(number, edge)
+
+    def add_vrrp_group(self, vlan_number, group_id, ips=None, priority=None,
+                       hello_interval=None, dead_interval=None ,track_id=None,
+                       track_decrement=None):
+        self.real_switch.add_vrrp_group(vlan_number, group_id, ips, priority,
+                                   hello_interval, dead_interval, track_id,
+                                   track_decrement)
+        self.vlans_cache[vlan_number].vrrp_groups.append(VrrpGroup(
+            id=group_id, ips=ips, priority=priority,
+            hello_interval=hello_interval, dead_interval=dead_interval,
+            track_id=track_id, track_decrement=track_decrement
+        ))
+
+    def remove_vrrp_group(self, vlan_number, group_id):
+        self.real_switch.remove_vrrp_group(vlan_number, group_id)
+        for group in self.vlans_cache[vlan_number].vrrp_groups:
+            if group.id == group_id:
+                self.vlans_cache[vlan_number].vrrp_groups.remove(group)
+
+    def add_dhcp_relay_server(self, vlan_number, ip_address):
+        self.real_switch.add_dhcp_relay_server(vlan_number, ip_address)
+        self.vlans_cache[vlan_number].dhcp_relay_servers.append(ip_address)
+
+    def remove_dhcp_relay_server(self, vlan_number, ip_address):
+        self.real_switch.add_dhcp_relay_server(vlan_number, ip_address)
+        try:
+            self.vlans_cache[vlan_number].dhcp_relay_servers.remove(ip_address)
+        except ValueError:
+            pass
+
+    def enable_lldp(self, interface_id, enabled):
+        self.real_switch.enable_lldp(interface_id, enabled)

--- a/netman/core/objects/bond.py
+++ b/netman/core/objects/bond.py
@@ -17,4 +17,7 @@ class Bond(object):
         self.number = number
         self.interface = interface
         self.link_speed = link_speed
-        self.members = members
+        self.members = members or []
+
+    def __eq__(self, other):
+        return self.__dict__ == other.__dict__

--- a/netman/core/objects/interface.py
+++ b/netman/core/objects/interface.py
@@ -23,3 +23,7 @@ class Interface(object):
         self.trunk_native_vlan = trunk_native_vlan
         self.trunk_vlans = trunk_vlans or []
         self.bond_master = bond_master
+
+    def __eq__(self, other):
+        return self.__dict__ == other.__dict__
+

--- a/netman/core/objects/vlan.py
+++ b/netman/core/objects/vlan.py
@@ -25,3 +25,6 @@ class Vlan(object):
         self.ips = ips or []
         self.vrrp_groups = vrrp_groups or []
         self.dhcp_relay_servers = dhcp_relay_servers or []
+
+    def __eq__(self, other):
+        return self.__dict__ == other.__dict__

--- a/netman/core/objects/vrrp_group.py
+++ b/netman/core/objects/vrrp_group.py
@@ -22,3 +22,6 @@ class VrrpGroup(object):
         self.dead_interval = dead_interval
         self.track_id = track_id
         self.track_decrement = track_decrement
+
+    def __eq__(self, other):
+        return self.__dict__ == other.__dict__

--- a/tests/adapters/switches/cached_test.py
+++ b/tests/adapters/switches/cached_test.py
@@ -1,0 +1,653 @@
+# Copyright 2015 Internap.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from hamcrest import assert_that, is_
+from flexmock import flexmock, flexmock_teardown
+from netman.adapters.switches.cached import CachedSwitch
+from netman.core.objects.bond import Bond
+from netman.core.objects.interface import Interface
+from netman.core.objects.vlan import Vlan
+from netman.core.objects.switch_descriptor import SwitchDescriptor
+from netman.core.objects.vrrp_group import VrrpGroup
+from netman.core.objects import access_groups, port_modes
+
+
+class CacheSwitchTest(unittest.TestCase):
+    def setUp(self):
+        self.real_switch_mock = flexmock()
+        self.real_switch_mock.switch_descriptor = SwitchDescriptor(
+            'model', 'hostname')
+        self.switch = CachedSwitch(self.real_switch_mock)
+
+    def tearDown(self):
+        flexmock_teardown()
+
+    def test_connect(self):
+        self.real_switch_mock.should_receive("connect").once()
+        self.switch.connect()
+
+    def test_disconnect(self):
+        self.real_switch_mock.should_receive("disconnect").once()
+        self.switch.disconnect()
+
+    def test_start_transaction(self):
+        self.real_switch_mock.should_receive("start_transaction").once()
+        self.switch.start_transaction()
+
+    def test_commit_transaction(self):
+        self.real_switch_mock.should_receive("commit_transaction").once()
+        self.switch.commit_transaction()
+
+    def test_rollback_transaction(self):
+        self.real_switch_mock.should_receive("rollback_transaction").once()
+        self.switch.rollback_transaction()
+
+    def test_end_transaction(self):
+        self.real_switch_mock.should_receive("end_transaction").once()
+        self.switch.end_transaction()
+
+    def test_get_vlans(self):
+        all_vlans = [Vlan(1, 'first'), Vlan(2, 'second')]
+
+        self.real_switch_mock.should_receive("get_vlans").once().and_return(
+            all_vlans)
+        assert_that(self.switch.get_vlans(), is_(all_vlans))
+        assert_that(self.switch.get_vlans(), is_(all_vlans))
+
+    def test_add_vlan_first(self):
+        all_vlans = [Vlan(1), Vlan(2), Vlan(123, name='allo')]
+
+        self.real_switch_mock.should_receive("add_vlan").once().with_args(123, 'allo')
+        self.switch.add_vlan(123, 'allo')
+
+        self.real_switch_mock.should_receive("get_vlans").once().and_return(
+            all_vlans)
+        assert_that(self.switch.get_vlans(), is_(all_vlans))
+        assert_that(self.switch.get_vlans(), is_(all_vlans))
+
+    def test_add_vlan_after_get_vlans(self):
+        all_vlans = [Vlan(1), Vlan(2)]
+
+        self.real_switch_mock.should_receive("get_vlans").once().and_return(
+            all_vlans)
+        assert_that(self.switch.get_vlans(), is_(all_vlans))
+        assert_that(self.switch.get_vlans(), is_(all_vlans))
+
+        self.real_switch_mock.should_receive("add_vlan").once().with_args(123, 'allo')
+        self.switch.add_vlan(123, 'allo')
+
+        assert_that(self.switch.get_vlans(), is_(all_vlans+[Vlan(123, name='allo')]))
+
+    def test_remove_vlan(self):
+        self.real_switch_mock.should_receive("get_vlans").once().and_return(
+            [Vlan(1), Vlan(2)])
+        self.switch.get_vlans()
+
+        self.real_switch_mock.should_receive("remove_vlan").once().with_args(1)
+        self.switch.remove_vlan(1)
+
+        assert_that(self.switch.get_vlans(), is_([Vlan(2)]))
+
+    def test_get_interfaces(self):
+        all_interfaces = [Interface('xe-1/0/1'), Interface('xe-1/0/2')]
+
+        self.real_switch_mock.should_receive("get_interfaces").once() \
+            .and_return(all_interfaces)
+        assert_that(self.switch.get_interfaces(), is_(all_interfaces))
+        assert_that(self.switch.get_interfaces(), is_(all_interfaces))
+
+    def test_set_access_vlan(self):
+        self.real_switch_mock.should_receive("get_interfaces").once().and_return(
+            [Interface('eth0')])
+        self.switch.get_interfaces()
+
+        self.real_switch_mock.should_receive("set_access_vlan").once() \
+            .with_args('eth0', 123)
+
+        self.switch.set_access_vlan('eth0', 123)
+
+        assert_that(
+            self.switch.get_interfaces(),
+            is_([Interface('eth0', access_vlan=123)])
+        )
+
+    def test_remove_access_vlan(self):
+        self.real_switch_mock.should_receive("get_interfaces").once().and_return(
+            [Interface('eth0', access_vlan=123)])
+        self.switch.get_interfaces()
+
+        self.real_switch_mock.should_receive("remove_access_vlan").once() \
+            .with_args('eth0')
+
+        self.switch.remove_access_vlan('eth0')
+
+        assert_that(
+            self.switch.get_interfaces(),
+            is_([Interface('eth0')])
+        )
+
+    def test_set_trunk_mode(self):
+        self.real_switch_mock.should_receive("get_interfaces").once().and_return(
+            [Interface('eth0')])
+        self.switch.get_interfaces()
+
+        self.real_switch_mock.should_receive("set_trunk_mode").once() \
+            .with_args('eth0')
+
+        self.switch.set_trunk_mode('eth0')
+
+        assert_that(
+            self.switch.get_interfaces(),
+            is_([Interface('eth0', port_mode=port_modes.TRUNK)])
+        )
+
+    def test_set_access_mode(self):
+        self.real_switch_mock.should_receive("get_interfaces").once().and_return(
+            [Interface('eth0')])
+        self.switch.get_interfaces()
+
+        self.real_switch_mock.should_receive("set_access_mode").once() \
+            .with_args('eth0')
+
+        self.switch.set_access_mode('eth0')
+
+        assert_that(
+            self.switch.get_interfaces(),
+            is_([Interface('eth0', port_mode=port_modes.ACCESS)])
+        )
+
+    def test_add_trunk_vlan(self):
+        self.real_switch_mock.should_receive("get_interfaces").once() \
+            .and_return([Interface('xe-1/0/2')])
+        self.switch.get_interfaces()
+
+        self.real_switch_mock.should_receive("add_trunk_vlan").once() \
+            .with_args('xe-1/0/2', 1)
+
+        self.switch.add_trunk_vlan('xe-1/0/2', 1)
+
+        assert_that(
+            self.switch.get_interfaces(),
+            is_([Interface('xe-1/0/2', trunk_vlans=[1])]))
+
+    def test_remove_trunk_vlan(self):
+        self.real_switch_mock.should_receive("get_interfaces").once() \
+            .and_return([Interface('xe-1/0/2', trunk_vlans=[1])])
+        self.switch.get_interfaces()
+
+        self.real_switch_mock.should_receive("remove_trunk_vlan").once() \
+            .with_args('xe-1/0/2', 1)
+
+        self.switch.remove_trunk_vlan('xe-1/0/2', 1)
+
+        assert_that(
+            self.switch.get_interfaces(),
+            is_([Interface('xe-1/0/2', trunk_vlans=[])]))
+
+    def test_shutdown_interface(self):
+        self.real_switch_mock.should_receive("get_interfaces").once() \
+            .and_return([Interface('xe-1/0/2', shutdown=False)])
+        self.switch.get_interfaces()
+
+        self.real_switch_mock.should_receive("shutdown_interface").once() \
+            .with_args('xe-1/0/2')
+
+        self.switch.shutdown_interface('xe-1/0/2')
+
+        assert_that(
+            self.switch.get_interfaces(),
+            is_([Interface('xe-1/0/2', shutdown=True)]))
+
+    def test_openup_interface(self):
+        self.real_switch_mock.should_receive("get_interfaces").once() \
+            .and_return([Interface('xe-1/0/2')])
+        self.switch.get_interfaces()
+
+        self.real_switch_mock.should_receive("openup_interface").once() \
+            .with_args('xe-1/0/2')
+
+        self.switch.openup_interface('xe-1/0/2')
+
+        assert_that(
+            self.switch.get_interfaces(),
+            is_([Interface('xe-1/0/2', shutdown=False)]))
+
+    def test_configure_native_vlan(self):
+        self.real_switch_mock.should_receive("get_interfaces").once() \
+            .and_return([Interface('xe-1/0/2')])
+        self.switch.get_interfaces()
+
+        self.real_switch_mock.should_receive("configure_native_vlan").once() \
+            .with_args('xe-1/0/2', 20)
+
+        self.switch.configure_native_vlan('xe-1/0/2', 20)
+
+        assert_that(
+            self.switch.get_interfaces(),
+            is_([Interface('xe-1/0/2', trunk_native_vlan=20)]))
+
+    def test_remove_native_vlan(self):
+        self.real_switch_mock.should_receive("get_interfaces").once() \
+            .and_return([Interface('xe-1/0/2', trunk_native_vlan=20)])
+        self.switch.get_interfaces()
+
+        self.real_switch_mock.should_receive("remove_native_vlan").once() \
+            .with_args('xe-1/0/2')
+
+        self.switch.remove_native_vlan('xe-1/0/2')
+
+        assert_that(
+            self.switch.get_interfaces(),
+            is_([Interface('xe-1/0/2', trunk_native_vlan=None)]))
+
+    def test_add_ip_to_vlan(self):
+        self.real_switch_mock.should_receive("get_vlans").once() \
+            .and_return([Vlan(2)])
+        self.switch.get_vlans()
+
+        self.real_switch_mock.should_receive("add_ip_to_vlan").once() \
+            .with_args(2, '127.0.0.1')
+
+        self.switch.add_ip_to_vlan(2, '127.0.0.1')
+
+        assert_that(
+            self.switch.get_vlans(),
+            is_([Vlan(2, ips=['127.0.0.1'])]))
+
+    def test_remove_ip_from_vlan(self):
+        self.real_switch_mock.should_receive("get_vlans").once() \
+            .and_return([Vlan(2, ips=['127.0.0.1'])])
+        self.switch.get_vlans()
+
+        self.real_switch_mock.should_receive("remove_ip_from_vlan").once() \
+            .with_args(2, '127.0.0.1')
+
+        self.switch.remove_ip_from_vlan(2, '127.0.0.1')
+
+        assert_that(
+            self.switch.get_vlans(),
+            is_([Vlan(2, ips=[])]))
+
+    def test_set_vlan_access_group(self):
+        self.real_switch_mock.should_receive("get_vlans").once() \
+            .and_return([Vlan(123)])
+        self.switch.get_vlans()
+
+        self.real_switch_mock.should_receive("set_vlan_access_group").once() \
+            .with_args(123, access_groups.IN, 'vlan-access-group')
+
+        self.switch.set_vlan_access_group(123, access_groups.IN, 'vlan-access-group')
+
+        assert_that(
+            self.switch.get_vlans(),
+            is_([Vlan(123, access_group_in='vlan-access-group')]))
+
+    def test_remove_vlan_access_group(self):
+        self.real_switch_mock.should_receive("get_vlans").once() \
+            .and_return([Vlan(123, access_group_out='vlan-access-group')])
+        self.switch.get_vlans()
+
+        self.real_switch_mock.should_receive("remove_vlan_access_group").once() \
+            .with_args(123, access_groups.OUT)
+
+        self.switch.remove_vlan_access_group(123, access_groups.OUT)
+
+        assert_that(
+            self.switch.get_vlans(),
+            is_([Vlan(123, access_group_out=None)]))
+
+    def test_set_vlan_vrf(self):
+        self.real_switch_mock.should_receive("get_vlans").once() \
+            .and_return([Vlan(123)])
+        self.switch.get_vlans()
+
+        self.real_switch_mock.should_receive("set_vlan_vrf").once() \
+            .with_args(123, 'vrf-name')
+
+        self.switch.set_vlan_vrf(123, 'vrf-name')
+
+        assert_that(
+            self.switch.get_vlans(),
+            is_([Vlan(123, vrf_forwarding='vrf-name')]))
+
+    def test_remove_vlan_vrf(self):
+        self.real_switch_mock.should_receive("get_vlans").once() \
+            .and_return([Vlan(123, vrf_forwarding='vrf-name')])
+        self.switch.get_vlans()
+
+        self.real_switch_mock.should_receive("remove_vlan_vrf").once() \
+            .with_args(123)
+
+        self.switch.remove_vlan_vrf(123)
+
+        assert_that(
+            self.switch.get_vlans(),
+            is_([Vlan(123, vrf_forwarding=None)]))
+
+
+    def test_set_interface_description(self):
+        self.real_switch_mock.should_receive("set_interface_description").once() \
+            .with_args('xe-1/0/2', 'interface-description')
+        self.switch.set_interface_description('xe-1/0/2', 'interface-description')
+
+    def test_remove_interface_description(self):
+        self.real_switch_mock.should_receive("remove_interface_description").once() \
+            .with_args('xe-1/0/2')
+        self.switch.remove_interface_description('xe-1/0/2')
+
+    def test_edit_interface_spanning_tree(self):
+        self.real_switch_mock.should_receive("edit_interface_spanning_tree").once() \
+            .with_args('xe-1/0/2', None)
+
+        self.switch.edit_interface_spanning_tree('xe-1/0/2')
+
+    def test_add_bond_first(self):
+        all_bonds = [Bond(1), Bond(2), Bond(123)]
+
+        self.real_switch_mock.should_receive("add_bond").once().with_args(123)
+        self.switch.add_bond(123)
+        assert_that(self.switch.get_bond(123).number, is_(123))
+
+        self.real_switch_mock.should_receive("get_bonds").once().and_return(
+            all_bonds)
+        assert_that(self.switch.get_bonds(), is_(all_bonds))
+        assert_that(self.switch.get_bonds(), is_(all_bonds))
+
+    def test_add_bond_after_get_bonds(self):
+        all_bonds = [Bond(1), Bond(2)]
+
+        self.real_switch_mock.should_receive("get_bonds").once().and_return(
+            all_bonds)
+        assert_that(self.switch.get_bonds(), is_(all_bonds))
+        assert_that(self.switch.get_bonds(), is_(all_bonds))
+
+        self.real_switch_mock.should_receive("add_bond").once().with_args(123)
+        self.switch.add_bond(123)
+        assert_that(self.switch.get_bond(123).number, is_(123))
+
+        assert_that(self.switch.get_bonds(), is_(all_bonds+[Bond(123)]))
+
+    def test_remove_bond(self):
+        self.real_switch_mock.should_receive("get_bonds").once().and_return(
+            [Bond(1), Bond(2)])
+        self.switch.get_bonds()
+
+        self.real_switch_mock.should_receive("remove_bond").once().with_args(2)
+        self.switch.remove_bond(2)
+
+        assert_that(self.switch.get_bonds(), is_([Bond(1)]))
+
+    def test_get_bonds(self):
+        all_bonds = [Bond(1), Bond(2)]
+
+        self.real_switch_mock.should_receive("get_bonds").once().and_return(
+            all_bonds)
+        assert_that(self.switch.get_bonds(), is_(all_bonds))
+        assert_that(self.switch.get_bonds(), is_(all_bonds))
+
+    def test_get_bond(self):
+        bond = Bond(2)
+        all_bonds = [Bond(1), bond]
+
+        self.real_switch_mock.should_receive("get_bond").once().with_args(2) \
+            .and_return(bond)
+        assert_that(self.switch.get_bond(2), is_(bond))
+        assert_that(self.switch.get_bond(2), is_(bond))
+
+        self.real_switch_mock.should_receive("get_bonds").once().and_return(
+            all_bonds)
+        assert_that(self.switch.get_bonds(), is_(all_bonds))
+        assert_that(self.switch.get_bonds(), is_(all_bonds))
+
+    def test_add_interface_to_bond(self):
+        self.real_switch_mock.should_receive("get_bonds").once() \
+            .and_return([Bond(1, interface=Interface())])
+        self.real_switch_mock.should_receive("get_interfaces").once() \
+            .and_return([Interface('xe-1/0/2')])
+
+        self.switch.get_bonds()
+        self.switch.get_interfaces()
+
+        self.real_switch_mock.should_receive("add_interface_to_bond").once() \
+            .with_args('xe-1/0/2', 1)
+
+        self.switch.add_interface_to_bond('xe-1/0/2', 1)
+
+        assert_that(
+            self.switch.get_bonds(),
+            is_([Bond(1, interface=Interface(), members=['xe-1/0/2'])]))
+        assert_that(
+            self.switch.get_interfaces(),
+            is_([Interface('xe-1/0/2', bond_master=1)]))
+
+    def test_remove_interface_from_bond(self):
+        self.real_switch_mock.should_receive("get_bonds").once() \
+            .and_return([Bond(1, interface=Interface(), members=['xe-1/0/2'])])
+        self.real_switch_mock.should_receive("get_interfaces").once() \
+            .and_return([Interface('xe-1/0/2', bond_master=1)])
+
+        self.switch.get_bonds()
+        self.switch.get_interfaces()
+
+        self.real_switch_mock.should_receive("remove_interface_from_bond").once() \
+            .with_args('xe-1/0/2')
+
+        self.switch.remove_interface_from_bond('xe-1/0/2')
+
+        assert_that(
+            self.switch.get_bonds(),
+            is_([Bond(1, interface=Interface(), members=[])]))
+        assert_that(
+            self.switch.get_interfaces(),
+            is_([Interface('xe-1/0/2', bond_master=None)]))
+
+    def test_set_bond_link_speed(self):
+        self.real_switch_mock.should_receive("get_bonds").once().and_return(
+            [Bond(1)])
+        self.switch.get_bonds()
+
+        self.real_switch_mock.should_receive("set_bond_link_speed").once() \
+            .with_args(1, 'super-fast')
+
+        self.switch.set_bond_link_speed(1, 'super-fast')
+
+        assert_that(
+            self.switch.get_bonds(),
+            is_([Bond(1, link_speed='super-fast')])
+        )
+
+    def test_set_bond_description(self):
+        self.real_switch_mock.should_receive("set_bond_description").once() \
+            .with_args(312, 'bond-description')
+        self.switch.set_bond_description(312, 'bond-description')
+
+    def test_remove_bond_description(self):
+        self.real_switch_mock.should_receive("remove_bond_description").once() \
+            .with_args(312)
+        self.switch.remove_bond_description(312)
+
+    def test_set_bond_trunk_mode(self):
+        self.real_switch_mock.should_receive("get_bonds").once().and_return(
+            [Bond(1, interface=Interface())])
+        self.switch.get_bonds()
+
+        self.real_switch_mock.should_receive("set_bond_trunk_mode").once() \
+            .with_args(1)
+
+        self.switch.set_bond_trunk_mode(1)
+
+        assert_that(
+            self.switch.get_bonds(),
+            is_([Bond(1, interface=Interface(port_mode=port_modes.TRUNK))])
+        )
+
+    def test_set_bond_access_mode(self):
+        self.real_switch_mock.should_receive("get_bonds").once().and_return(
+            [Bond(1, interface=Interface())])
+        self.switch.get_bonds()
+
+        self.real_switch_mock.should_receive("set_bond_access_mode").once() \
+            .with_args(1)
+
+        self.switch.set_bond_access_mode(1)
+
+        assert_that(
+            self.switch.get_bonds(),
+            is_([Bond(1, interface=Interface(port_mode=port_modes.ACCESS))])
+        )
+
+    def test_add_bond_trunk_vlan_first(self):
+        self.real_switch_mock.should_receive("add_bond_trunk_vlan").once() \
+            .with_args(1, 2)
+
+        self.switch.add_bond_trunk_vlan(1, 2)
+
+        self.real_switch_mock.should_receive("get_bond").once().with_args(1) \
+            .and_return(Bond(1))
+        assert_that(self.switch.get_bond(1), is_(Bond(1)))
+        assert_that(self.switch.get_bond(1), is_(Bond(1)))
+
+    def test_add_bond_trunk_vlan_after_get_bonds(self):
+        all_bonds = [Bond(1, interface=Interface()),
+                     Bond(2, interface=Interface())]
+
+        self.real_switch_mock.should_receive("get_bonds").once().and_return(
+            all_bonds)
+        assert_that(self.switch.get_bonds(), is_(all_bonds))
+
+        self.real_switch_mock.should_receive("add_bond_trunk_vlan").once() \
+            .with_args(1, 2)
+
+        self.switch.add_bond_trunk_vlan(1, 2)
+
+        assert_that(
+            self.switch.get_bond(1),
+            is_(Bond(1, interface=Interface(trunk_vlans=[2])))
+        )
+        assert_that(
+            self.switch.get_bonds(),
+            is_([
+                Bond(1, interface=Interface(trunk_vlans=[2])),
+                Bond(2, interface=Interface())
+            ])
+        )
+
+    def test_remove_bond_trunk_vlan(self):
+        all_bonds = [Bond(1, interface=Interface(trunk_vlans=[2])),
+                     Bond(2, interface=Interface())]
+
+        self.real_switch_mock.should_receive("get_bonds").once().and_return(
+            all_bonds)
+        assert_that(self.switch.get_bonds(), is_(all_bonds))
+
+        self.real_switch_mock.should_receive("remove_bond_trunk_vlan").once() \
+            .with_args(1, 2)
+
+        self.switch.remove_bond_trunk_vlan(1, 2)
+
+        assert_that(
+            self.switch.get_bond(1),
+            is_(Bond(1, interface=Interface(trunk_vlans=[])))
+        )
+        assert_that(
+            self.switch.get_bonds(),
+            is_([
+                Bond(1, interface=Interface(trunk_vlans=[])),
+                Bond(2, interface=Interface())
+            ])
+        )
+
+    def test_configure_bond_native_vlan(self):
+        self.real_switch_mock.should_receive("get_bonds").once() \
+            .and_return([Bond(2, interface=Interface())])
+        self.switch.get_bonds()
+
+        self.real_switch_mock.should_receive("configure_bond_native_vlan").once() \
+            .with_args(2, 20)
+
+        self.switch.configure_bond_native_vlan(2, 20)
+
+        assert_that(
+            self.switch.get_bonds(),
+            is_([Bond(2, interface=Interface(trunk_native_vlan=20))]))
+
+    def test_remove_bond_native_vlan(self):
+        self.real_switch_mock.should_receive("get_bonds").once() \
+            .and_return([Bond(2, interface=Interface(trunk_native_vlan=20))])
+        self.switch.get_bonds()
+
+        self.real_switch_mock.should_receive("remove_bond_native_vlan").once() \
+            .with_args(2)
+
+        self.switch.remove_bond_native_vlan(2)
+
+        assert_that(
+            self.switch.get_bonds(),
+            is_([Bond(2, interface=Interface(trunk_native_vlan=None))]))
+
+    def test_edit_bond_spanning_tree(self):
+        self.real_switch_mock.should_receive("edit_bond_spanning_tree").once() \
+            .with_args(2, None)
+
+        self.switch.edit_bond_spanning_tree(2)
+
+    def test_add_vrrp_group(self):
+        self.real_switch_mock.should_receive("get_vlans").once() \
+            .and_return([Vlan(1)])
+        self.switch.get_vlans()
+
+        self.real_switch_mock.should_receive("add_vrrp_group").once() \
+            .with_args(1, 2, None, None, None, None, None, None)
+
+        self.switch.add_vrrp_group(1, 2)
+
+        assert_that(
+            self.switch.get_vlans(),
+            is_([Vlan(1, vrrp_groups=[VrrpGroup(id=2)])]))
+
+    def test_remove_vrrp_group(self):
+        self.real_switch_mock.should_receive("get_vlans").once() \
+            .and_return([Vlan(1, vrrp_groups=[VrrpGroup(id=2)])])
+        self.switch.get_vlans()
+
+        self.real_switch_mock.should_receive("remove_vrrp_group").once() \
+            .with_args(1, 2)
+
+        self.switch.remove_vrrp_group(1, 2)
+
+        assert_that(
+            self.switch.get_vlans(),
+            is_([Vlan(1, vrrp_groups=[])]))
+
+    def test_add_dhcp_relay_server(self):
+        self.real_switch_mock.should_receive("get_vlans").once() \
+            .and_return([Vlan(2)])
+        self.switch.get_vlans()
+
+        self.real_switch_mock.should_receive("add_dhcp_relay_server").once() \
+            .with_args(2, '127.0.0.1')
+
+        self.switch.add_dhcp_relay_server(2, '127.0.0.1')
+
+        assert_that(
+            self.switch.get_vlans(),
+            is_([Vlan(2, dhcp_relay_servers=['127.0.0.1'])]))
+
+    def test_enable_lldp(self):
+        self.real_switch_mock.should_receive("enable_lldp").once() \
+            .with_args('xe-1/0/2', True)
+
+        self.switch.enable_lldp('xe-1/0/2', True)

--- a/tests/adapters/switches/remote_test.py
+++ b/tests/adapters/switches/remote_test.py
@@ -418,7 +418,7 @@ class RemoteSwitchTest(unittest.TestCase):
         assert_that(if1.interface.access_vlan, equal_to(1999))
         assert_that(if1.interface.trunk_native_vlan, equal_to(None))
         assert_that(if1.interface.trunk_vlans, equal_to([]))
-        assert_that(if1.members, equal_to(None))
+        assert_that(if1.members, equal_to([]))
 
     def test_get_bonds(self):
         self.requests_mock.should_receive("get").once().with_args(
@@ -439,7 +439,7 @@ class RemoteSwitchTest(unittest.TestCase):
         assert_that(if1.interface.access_vlan, equal_to(1999))
         assert_that(if1.interface.trunk_native_vlan, equal_to(None))
         assert_that(if1.interface.trunk_vlans, equal_to([]))
-        assert_that(if1.members, equal_to(None))
+        assert_that(if1.members, equal_to([]))
 
         assert_that(if2.number, equal_to(4))
         assert_that(if2.members, equal_to(["ge-0/0/1", "ge-1/0/1"]))
@@ -459,7 +459,7 @@ class RemoteSwitchTest(unittest.TestCase):
         assert_that(if3.interface.access_vlan, equal_to(1999))
         assert_that(if3.interface.trunk_native_vlan, equal_to(2999))
         assert_that(if3.interface.trunk_vlans, equal_to([3000, 3001, 3002]))
-        assert_that(if3.members, equal_to(None))
+        assert_that(if3.members, equal_to([]))
 
     def test_add_vlan(self):
         self.requests_mock.should_receive("post").once().with_args(

--- a/tests/api/fixtures/get_switch_hostname_bond.json
+++ b/tests/api/fixtures/get_switch_hostname_bond.json
@@ -1,7 +1,7 @@
 {
    "number": 3,
    "link_speed": "1g",
-   "members": null,
+   "members": [],
    "interface": {
       "name": "ae3",
       "shutdown": true,

--- a/tests/api/fixtures/get_switch_hostname_bonds.json
+++ b/tests/api/fixtures/get_switch_hostname_bonds.json
@@ -2,7 +2,7 @@
    {
       "number": 3,
       "link_speed": "1g",
-      "members": null,
+      "members": [],
       "interface": {
          "name": "ae3",
          "shutdown": true,
@@ -37,7 +37,7 @@
    {
       "number": 6,
       "link_speed": "10g",
-      "members": null,
+      "members": [],
       "interface": {
          "name": "ae6",
          "shutdown": false,


### PR DESCRIPTION
Within a transaction, it is safe to assume that any change made
to a switch may be cached locally, thus avoiding to fetch the
same data over and over.  The CachedSwitch class is a SwitchBase
proxy caching each change made to the switch.  Using this class,
get_vlans, get_interfaces, get_bonds and get_bond methods may be
called multiple time without performance issue.