### PR TITLE
Changed the brocade contract to require ethernet in the port name

### DIFF
--- a/netman/adapters/switches/__init__.py
+++ b/netman/adapters/switches/__init__.py
@@ -11,76 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import logging
-import re
-import traceback
 
-from netman import regex
+from netman.adapters.switches.backward_compatible_brocade import BackwardCompatibleBrocade
+from netman.core.objects.switch_transactional import SwitchTransactional
 
 
-class SubShell(object):
-    debug = False
-
-    def __init__(self, ssh, enter, exit_cmd, validate=None):
-        self.ssh = ssh
-        self.enter = enter
-        self.exit = exit_cmd
-        self.validate = validate or (lambda x: None)
-
-    def __enter__(self):
-        if isinstance(self.enter, list):
-            [self.validate(self.ssh.do(cmd)) for cmd in self.enter]
-        else:
-            self.validate(self.ssh.do(self.enter))
-        return self.ssh
-
-    def __exit__(self, eType, eValue, eTrace):
-        if self.debug and eType is not None:
-            logging.error("Subshell exception {}: {}\n{}".format(eType.__name__, eValue, "".join(traceback.format_tb(eTrace))))
-
-        self.ssh.do(self.exit)
-
-
-def no_output(exc, *args):
-    def m(welcome_msg):
-        if len(welcome_msg) > 0:
-            raise exc(*args)
-    return m
-
-
-def split_on_bang(data):
-    current_chunk = []
-    for line in data:
-        if re.match("^!.*", line):
-            if len(current_chunk) > 0:
-                yield current_chunk
-                current_chunk = []
-        else:
-            current_chunk.append(line)
-
-
-def split_on_dedent(data):
-    current_chunk = []
-    for line in data:
-        if re.match("^[^\s].*", line) and len(current_chunk) > 0:
-            yield current_chunk
-            current_chunk = [line]
-        else:
-            current_chunk.append(line)
-
-    yield current_chunk
-
-
-class ResultChecker(object):
-    def __init__(self, result=None):
-        self.result = result
-
-    def on_any_result(self, exception, *args, **kwargs):
-        if self.result and len(self.result) > 0:
-            raise exception(*args, **kwargs)
-        return self
-
-    def on_result_matching(self, matcher, exception, *args, **kwargs):
-        if regex.match(matcher, "\n".join(self.result), flags=re.DOTALL):
-            raise exception(*args, **kwargs)
-        return self
+def brocade_factory(switch_descriptor, lock):
+    return SwitchTransactional(
+        impl=BackwardCompatibleBrocade(switch_descriptor=switch_descriptor),
+        lock=lock
+    )

--- a/netman/adapters/switches/backward_compatible_brocade.py
+++ b/netman/adapters/switches/backward_compatible_brocade.py
@@ -1,0 +1,71 @@
+# Copyright 2015 Internap.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+
+from netman.adapters.switches.brocade import Brocade
+import re
+
+
+class BackwardCompatibleBrocade(Brocade):
+    def __init__(self, switch_descriptor):
+        super(BackwardCompatibleBrocade, self).__init__(switch_descriptor)
+
+        self.logger = logging.getLogger(
+            "{module}.{hostname}".format(module=Brocade.__module__,
+                                         hostname=self.switch_descriptor.hostname))
+
+    def add_trunk_vlan(self, interface_id, vlan):
+        return super(BackwardCompatibleBrocade, self).add_trunk_vlan(_add_ethernet(interface_id), vlan)
+
+    def shutdown_interface(self, interface_id):
+        return super(BackwardCompatibleBrocade, self).shutdown_interface(_add_ethernet(interface_id))
+
+    def set_trunk_mode(self, interface_id):
+        return super(BackwardCompatibleBrocade, self).set_trunk_mode(_add_ethernet(interface_id))
+
+    def set_access_vlan(self, interface_id, vlan):
+        return super(BackwardCompatibleBrocade, self).set_access_vlan(_add_ethernet(interface_id), vlan)
+
+    def set_access_mode(self, interface_id):
+        return super(BackwardCompatibleBrocade, self).set_access_mode(_add_ethernet(interface_id))
+
+    def remove_trunk_vlan(self, interface_id, vlan):
+        super(BackwardCompatibleBrocade, self).remove_trunk_vlan(_add_ethernet(interface_id), vlan)
+
+    def remove_native_vlan(self, interface_id):
+        return super(BackwardCompatibleBrocade, self).remove_native_vlan(_add_ethernet(interface_id))
+
+    def remove_access_vlan(self, interface_id):
+        return super(BackwardCompatibleBrocade, self).remove_access_vlan(_add_ethernet(interface_id))
+
+    def openup_interface(self, interface_id):
+        return super(BackwardCompatibleBrocade, self).openup_interface(_add_ethernet(interface_id))
+
+    def interface(self, interface_id):
+        return super(BackwardCompatibleBrocade, self).interface(_add_ethernet(interface_id))
+
+    def configure_native_vlan(self, interface_id, vlan):
+        return super(BackwardCompatibleBrocade, self).configure_native_vlan(_add_ethernet(interface_id), vlan)
+
+    def add_vrrp_group(self, vlan_number, group_id, ips=None, priority=None, hello_interval=None, dead_interval=None,
+                       track_id=None, track_decrement=None):
+        return super(BackwardCompatibleBrocade, self).add_vrrp_group(vlan_number, group_id, ips, priority,
+                                                                     hello_interval, dead_interval,
+                                                                     _add_ethernet(track_id), track_decrement)
+
+
+def _add_ethernet(interface_id):
+    if interface_id is not None and re.match("^\d.*", interface_id):
+        return "ethernet {}".format(interface_id)
+    return interface_id

--- a/netman/adapters/switches/cisco.py
+++ b/netman/adapters/switches/cisco.py
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import re
-
 from netaddr.ip import IPNetwork, IPAddress
 
 from netman import regex
-from netman.adapters.switches import SubShell, split_on_dedent, split_on_bang, no_output
+from netman.adapters.switches.util import SubShell, split_on_dedent, split_on_bang, no_output
 from netman.adapters.shell import ssh
 from netman.core.objects.access_groups import IN, OUT
 from netman.core.objects.exceptions import IPNotAvailable, UnknownVlan, UnknownIP, UnknownAccessGroup, BadVlanNumber, \

--- a/netman/adapters/switches/dell.py
+++ b/netman/adapters/switches/dell.py
@@ -20,7 +20,7 @@ from netman.adapters.switches.cisco import parse_vlan_ranges
 from netman.core.objects.vlan import Vlan
 from netman import regex
 from netman.core.objects.switch_transactional import SwitchTransactional
-from netman.adapters.switches import SubShell, no_output, ResultChecker
+from netman.adapters.switches.util import SubShell, no_output, ResultChecker
 from netman.core.objects.exceptions import UnknownInterface, BadVlanName, \
     BadVlanNumber, UnknownVlan, InterfaceInWrongPortMode, NativeVlanNotSet, TrunkVlanNotSet, BadInterfaceDescription
 from netman.core.objects.switch_base import SwitchBase

--- a/netman/adapters/switches/util.py
+++ b/netman/adapters/switches/util.py
@@ -1,0 +1,88 @@
+# Copyright 2015 Internap.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import traceback
+
+from netman import regex
+import re
+
+
+class SubShell(object):
+    debug = False
+
+    def __init__(self, ssh, enter, exit_cmd, validate=None):
+        self.ssh = ssh
+        self.enter = enter
+        self.exit = exit_cmd
+        self.validate = validate or (lambda x: None)
+
+    def __enter__(self):
+        if isinstance(self.enter, list):
+            [self.validate(self.ssh.do(cmd)) for cmd in self.enter]
+        else:
+            self.validate(self.ssh.do(self.enter))
+        return self.ssh
+
+    def __exit__(self, eType, eValue, eTrace):
+        if self.debug and eType is not None:
+            logging.error("Subshell exception {}: {}\n{}"
+                          .format(eType.__name__, eValue, "".join(traceback.format_tb(eTrace))))
+
+        self.ssh.do(self.exit)
+
+
+def no_output(exc, *args):
+    def m(welcome_msg):
+        if len(welcome_msg) > 0:
+            raise exc(*args)
+    return m
+
+
+def split_on_bang(data):
+    current_chunk = []
+    for line in data:
+        if re.match("^!.*", line):
+            if len(current_chunk) > 0:
+                yield current_chunk
+                current_chunk = []
+        else:
+            current_chunk.append(line)
+
+
+def split_on_dedent(data):
+    current_chunk = []
+    for line in data:
+        if re.match("^[^\s].*", line) and len(current_chunk) > 0:
+            yield current_chunk
+            current_chunk = [line]
+        else:
+            current_chunk.append(line)
+
+    yield current_chunk
+
+
+class ResultChecker(object):
+    def __init__(self, result=None):
+        self.result = result
+
+    def on_any_result(self, exception, *args, **kwargs):
+        if self.result and len(self.result) > 0:
+            raise exception(*args, **kwargs)
+        return self
+
+    def on_result_matching(self, matcher, exception, *args, **kwargs):
+        if regex.match(matcher, "\n".join(self.result), flags=re.DOTALL):
+            raise exception(*args, **kwargs)
+        return self

--- a/netman/core/objects/switch_transactional.py
+++ b/netman/core/objects/switch_transactional.py
@@ -14,7 +14,6 @@
 
 from contextlib import contextmanager
 from functools import wraps
-import logging
 
 from .switch_base import SwitchOperations
 
@@ -35,9 +34,7 @@ class SwitchTransactional(SwitchOperations):
     def __init__(self, impl, lock):
         self.impl = impl
         self.lock = lock
-        self.logger = logging.getLogger("{module}.{hostname}".format(
-            module=self.impl.__module__,
-            hostname=self.switch_descriptor.hostname))
+        self.logger = self.impl.logger
         self.in_transaction = False
 
     @property

--- a/netman/core/switch_factory.py
+++ b/netman/core/switch_factory.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from netman.adapters.switches import cisco, juniper, brocade, remote, dell, dell10g
+from netman.adapters.switches import cisco, juniper, remote, dell, dell10g, brocade_factory
 from netman.core.objects.switch_descriptor import SwitchDescriptor
 
 
@@ -24,7 +24,7 @@ class SwitchFactory(object):
 
         self.factories = {
             "cisco": cisco.factory,
-            "brocade": brocade.factory,
+            "brocade": brocade_factory,
             "juniper": juniper.standard_factory,
             "juniper_qfx_copper": juniper.qfx_copper_factory,
             "dell": dell.factory_ssh,

--- a/tests/adapters/switches/brocade_backward_compatibility_test.py
+++ b/tests/adapters/switches/brocade_backward_compatibility_test.py
@@ -1,0 +1,210 @@
+# Copyright 2015 Internap.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from netman.adapters.switches.util import SubShell
+from tests.adapters.switches.brocade_test import vlan_with_vif_display, vlan_display
+from flexmock import flexmock, flexmock_teardown
+import mock
+from netaddr.ip import IPAddress
+from netman.adapters.switches import brocade_factory
+from netman.core.objects.switch_descriptor import SwitchDescriptor
+
+
+class BrocadeBackwardCompatibilityTest(unittest.TestCase):
+
+    def setUp(self):
+        self.lock = mock.Mock()
+        self.switch = brocade_factory(SwitchDescriptor(model='brocade', hostname="my.hostname"), self.lock)
+        SubShell.debug = True
+
+    def tearDown(self):
+        flexmock_teardown()
+
+    def command_setup(self):
+        self.mocked_ssh_client = flexmock()
+        self.switch.impl.ssh = self.mocked_ssh_client
+
+    def test_set_access_vlan_accepts_no_ethernet(self):
+        self.command_setup()
+
+        self.mocked_ssh_client.should_receive("do").with_args("show vlan 2999").once().ordered().and_return(
+            vlan_display(2999)
+        )
+
+        self.mocked_ssh_client.should_receive("do").with_args("configure terminal").and_return([]).once().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("vlan 2999").and_return([]).once().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("untagged ethernet 1/4").and_return([]).once().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("exit").and_return([]).twice().ordered().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("write memory").and_return([]).once().ordered()
+
+        self.switch.set_access_vlan("1/4", vlan=2999)
+
+    def test_remove_access_vlan_accepts_no_ethernet(self):
+        self.command_setup()
+
+        self.mocked_ssh_client.should_receive("do").with_args("show vlan brief | include ethe 1/4").once().ordered().and_return([
+            "1202     your-name-                                        1202  -  Untagged Ports : ethe 1/10"
+        ])
+
+        self.mocked_ssh_client.should_receive("do").with_args("configure terminal").once().ordered().and_return([])
+        self.mocked_ssh_client.should_receive("do").with_args("vlan 1202").and_return([]).once().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("no untagged ethernet 1/4").and_return([]).once().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("exit").and_return([]).twice().ordered().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("write memory").and_return([]).once().ordered()
+
+        self.switch.remove_access_vlan("1/4")
+
+    def test_set_access_mode_accepts_no_ethernet(self):
+        self.command_setup()
+
+        self.mocked_ssh_client.should_receive("do").with_args("show vlan ethernet 1/4").once().ordered().and_return([
+            "VLAN: 100  Tagged",
+            "VLAN: 300  Untagged",
+        ])
+
+        self.mocked_ssh_client.should_receive("do").with_args("configure terminal").once().ordered().and_return([])
+        self.mocked_ssh_client.should_receive("do").with_args("vlan 100").and_return([]).once().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("no tagged ethernet 1/4").and_return([]).once().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("vlan 300").and_return([]).once().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("no untagged ethernet 1/4").and_return([]).once().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("exit").and_return([]).twice().ordered().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("write memory").and_return([]).once().ordered()
+
+        self.switch.set_access_mode("1/4")
+
+    def test_set_trunk_mode_accepts_no_ethernet(self):
+        self.command_setup()
+
+        self.mocked_ssh_client.should_receive("do").with_args("show vlan ethernet 1/4").once().ordered().and_return([
+            "VLAN: 1  Untagged"
+        ])
+
+        self.mocked_ssh_client.should_receive("do").with_args("configure terminal").never()
+        self.mocked_ssh_client.should_receive("do").with_args("write memory").and_return([]).once().ordered()
+
+        self.switch.set_trunk_mode("1/4")
+
+    def test_add_trunk_vlan_accepts_no_ethernet(self):
+        self.command_setup()
+
+        self.mocked_ssh_client.should_receive("do").with_args("show vlan 2999").once().ordered().and_return(
+            vlan_display(2999)
+        )
+
+        self.mocked_ssh_client.should_receive("do").with_args("configure terminal").and_return([]).once().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("vlan 2999").and_return([]).once().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("tagged ethernet 1/1").and_return([]).once().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("exit").and_return([]).twice().ordered().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("write memory").and_return([]).once().ordered()
+
+        self.switch.add_trunk_vlan("1/1", vlan=2999)
+
+    def test_remove_trunk_vlan_accepts_no_ethernet(self):
+        self.command_setup()
+
+        self.mocked_ssh_client.should_receive("do").with_args("show vlan 2999").once().ordered().and_return(
+            vlan_display(2999)
+        )
+
+        self.mocked_ssh_client.should_receive("do").with_args("configure terminal").and_return([]).once().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("vlan 2999").and_return([]).once().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("no tagged ethernet 1/11").and_return([]).once().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("exit").and_return([]).twice().ordered().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("write memory").and_return([]).once().ordered()
+
+        self.switch.remove_trunk_vlan("1/11", vlan=2999)
+
+    def test_shutdown_interface_accepts_no_ethernet(self):
+        self.command_setup()
+
+        self.mocked_ssh_client.should_receive("do").with_args("configure terminal").once().ordered().and_return([])
+        self.mocked_ssh_client.should_receive("do").with_args("interface ethernet 1/4").and_return([]).once().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("disable").and_return([]).once().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("exit").and_return([]).twice().ordered().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("write memory").and_return([]).once().ordered()
+
+        self.switch.shutdown_interface("1/4")
+
+    def test_openup_interface_accepts_no_ethernet(self):
+        self.command_setup()
+
+        self.mocked_ssh_client.should_receive("do").with_args("configure terminal").once().ordered().and_return([])
+        self.mocked_ssh_client.should_receive("do").with_args("interface ethernet 1/4").and_return([]).once().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("enable").and_return([]).once().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("exit").and_return([]).twice().ordered().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("write memory").and_return([]).once().ordered()
+
+        self.switch.openup_interface("1/4")
+
+    def test_configure_native_vlan_backward_compatibility(self):
+        self.command_setup()
+
+        self.mocked_ssh_client.should_receive("do").with_args("show vlan 2999").once().ordered().and_return(
+            vlan_display(2999)
+        )
+
+        self.mocked_ssh_client.should_receive("do").with_args("configure terminal").once().ordered().and_return([])
+        self.mocked_ssh_client.should_receive("do").with_args("vlan 2999").and_return([]).once().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("untagged ethernet 1/4").and_return([]).once().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("exit").and_return([]).twice().ordered().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("write memory").and_return([]).once().ordered()
+
+        self.switch.configure_native_vlan("1/4", vlan=2999)
+
+    def test_remove_native_vlan_on_trunk_accepts_no_ethernet(self):
+        self.command_setup()
+
+        self.mocked_ssh_client.should_receive("do").with_args("show vlan brief | include ethe 1/4").once().ordered().and_return([
+            "1202     your-name-                                        1202  -  Untagged Ports : ethe 1/10"
+        ])
+
+        self.mocked_ssh_client.should_receive("do").with_args("configure terminal").once().ordered().and_return([])
+        self.mocked_ssh_client.should_receive("do").with_args("vlan 1202").and_return([]).once().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("no untagged ethernet 1/4").and_return([]).once().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("exit").and_return([]).twice().ordered().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("write memory").and_return([]).once().ordered()
+
+        self.switch.remove_native_vlan("1/4")
+
+    def test_add_vrrp_accepts_no_ethernet(self):
+        self.command_setup()
+
+        self.mocked_ssh_client.should_receive("do").with_args("show vlan 1234").once().ordered().and_return(
+            vlan_with_vif_display(1234, 1234)
+        )
+        self.mocked_ssh_client.should_receive("do").with_args("show running-config interface ve 1234").once().ordered().and_return([
+            "interface ve 1234",
+            " ip address 1.2.3.1/27",
+            "!",
+        ])
+
+        self.mocked_ssh_client.should_receive("do").with_args("configure terminal").once().ordered().and_return([])
+        self.mocked_ssh_client.should_receive("do").with_args("interface ve 1234").and_return([]).once().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("enable").and_return([]).once().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("ip vrrp-extended auth-type simple-text-auth VLAN1234").and_return([]).once().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("ip vrrp-extended vrid 1").and_return([]).once().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("backup priority 110 track-priority 50").and_return([]).once().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("ip-address 1.2.3.4").and_return([]).once().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("hello-interval 5").and_return([]).once().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("dead-interval 15").and_return([]).once().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("advertise backup").and_return([]).once().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("track-port ethernet 1/1").and_return([]).once().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("activate").and_return([]).once().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("exit").and_return([]).twice().ordered().ordered()
+        self.mocked_ssh_client.should_receive("do").with_args("write memory").and_return([]).once().ordered()
+
+        self.switch.add_vrrp_group(1234, 1, ips=[IPAddress("1.2.3.4")], priority=110, hello_interval=5, dead_interval=15,
+                                   track_id="1/1", track_decrement=50)

--- a/tests/adapters/switches/cisco_test.py
+++ b/tests/adapters/switches/cisco_test.py
@@ -19,8 +19,8 @@ from hamcrest import assert_that, has_length, equal_to, is_, instance_of, none, 
 import mock
 from netaddr import IPNetwork
 from netaddr.ip import IPAddress
-
-from netman.adapters.switches import cisco, SubShell
+from netman.adapters.switches import cisco
+from netman.adapters.switches.util import SubShell
 from netman.core.objects.switch_transactional import SwitchTransactional
 from netman.adapters.switches.cisco import Cisco, parse_vlan_ranges
 from netman.core.objects.access_groups import IN, OUT

--- a/tests/adapters/switches/dell10g_test.py
+++ b/tests/adapters/switches/dell10g_test.py
@@ -18,11 +18,11 @@ import unittest
 from hamcrest import assert_that, equal_to, is_, instance_of, has_length, none
 import mock
 from flexmock import flexmock, flexmock_teardown
-
 from netman.adapters.shell.telnet import TelnetClient
 from netman.adapters.shell.ssh import SshClient
+from netman.adapters.switches.util import SubShell
 from netman.core.objects.port_modes import ACCESS, TRUNK
-from netman.adapters.switches import dell10g, SubShell
+from netman.adapters.switches import dell10g
 from netman.adapters.switches.dell10g import Dell10G
 from netman.core.objects.switch_transactional import SwitchTransactional
 from netman.core.objects.exceptions import UnknownInterface, BadVlanNumber, \

--- a/tests/adapters/switches/dell_test.py
+++ b/tests/adapters/switches/dell_test.py
@@ -17,13 +17,12 @@ import unittest
 
 from hamcrest import assert_that, equal_to, is_, instance_of, has_length, none
 import mock
-
 from flexmock import flexmock, flexmock_teardown
-
 from netman.adapters.shell.telnet import TelnetClient
 from netman.adapters.shell.ssh import SshClient
+from netman.adapters.switches.util import SubShell
 from netman.core.objects.port_modes import ACCESS, TRUNK
-from netman.adapters.switches import dell, SubShell
+from netman.adapters.switches import dell
 from netman.adapters.switches.dell import Dell
 from netman.core.objects.switch_transactional import SwitchTransactional
 from netman.core.objects.exceptions import UnknownInterface, BadVlanNumber, \

--- a/tests/adapters/unified_tests/__init__.py
+++ b/tests/adapters/unified_tests/__init__.py
@@ -37,6 +37,7 @@ available_models = [
         "username": "root",
         "password": "root",
         "test_port_name": "FastEthernet0/3",
+        "test_vrrp_track_id": "101",
         "core_class": CiscoSwitchCore,
         "service_class": SwitchSshService,
         "ports": [
@@ -52,7 +53,8 @@ available_models = [
         "port": 11003,
         "username": "root",
         "password": "root",
-        "test_port_name": "1/3",
+        "test_port_name": "ethernet 1/3",
+        "test_vrrp_track_id": "ethernet 1/1",
         "core_class": BrocadeSwitchCore,
         "service_class": SwitchSshService,
         "ports": [

--- a/tests/adapters/unified_tests/configured_test_case.py
+++ b/tests/adapters/unified_tests/configured_test_case.py
@@ -61,12 +61,13 @@ class ConfiguredTestCase(unittest.TestCase):
 
     def setUp(self):
         specs = type(self).switch_specs
-        self.switch_hostname = specs["hostname"]
-        self.switch_port = specs["port"]
-        self.switch_type = specs["model"]
-        self.switch_username = specs["username"]
-        self.switch_password = specs["password"]
-        self.test_port = specs["test_port_name"]
+        self.switch_hostname = specs.get("hostname")
+        self.switch_port = specs.get("port")
+        self.switch_type = specs.get("model")
+        self.switch_username = specs.get("username")
+        self.switch_password = specs.get("password")
+        self.test_port = specs.get("test_port_name")
+        self.test_vrrp_track_id = specs.get("test_vrrp_track_id")
 
         self.remote_switch = RemoteSwitch(SwitchDescriptor(
             netman_server='', **sub_dict(

--- a/tests/adapters/unified_tests/vlan_management_test.py
+++ b/tests/adapters/unified_tests/vlan_management_test.py
@@ -33,7 +33,7 @@ class VlanManagementTest(ConfiguredTestCase):
         self.client.set_vlan_vrf(2999, "DEFAULT-LAN")
         self.client.add_ip_to_vlan(2999, IPNetwork("10.10.10.2/29"))
         self.client.add_vrrp_group(vlan_number=2999, group_id=73, ips=[IPAddress("10.10.0.1")], priority=110,
-                                   track_id="101", track_decrement=50, hello_interval=5, dead_interval=15)
+                                   track_id=self.test_vrrp_track_id, track_decrement=50, hello_interval=5, dead_interval=15)
         self.client.add_dhcp_relay_server(2999, IPAddress("10.10.10.11"))
 
         single_vlan = self.client.get_vlan(2999)

--- a/tests/adapters/unified_tests/vrrp_test.py
+++ b/tests/adapters/unified_tests/vrrp_test.py
@@ -32,7 +32,7 @@ class VrrpTest(ConfiguredTestCase):
                 group_id=73,
                 ips=[IPAddress("10.10.0.1"), IPAddress("10.10.0.2")],
                 priority=110,
-                track_id=101,
+                track_id=self.test_vrrp_track_id,
                 track_decrement=50,
                 hello_interval=5,
                 dead_interval=15
@@ -45,7 +45,7 @@ class VrrpTest(ConfiguredTestCase):
 
             assert_that([str(ip) for ip in vrrp_group.ips], is_(["10.10.0.1", "10.10.0.2"]))
             assert_that(vrrp_group.priority, is_(110))
-            assert_that(vrrp_group.track_id, is_('101'))
+            assert_that(vrrp_group.track_id, is_(self.test_vrrp_track_id))
             assert_that(vrrp_group.track_decrement, is_(50))
             assert_that(vrrp_group.hello_interval, is_(5))
             assert_that(vrrp_group.dead_interval, is_(15))

--- a/tests/core/objects/switch_transactional_test.py
+++ b/tests/core/objects/switch_transactional_test.py
@@ -11,12 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import logging
 from unittest import TestCase
 
 from flexmock import flexmock
 from hamcrest import assert_that, is_
-
 from netman.core.objects.exceptions import NetmanException
 from netman.core.objects.switch_descriptor import SwitchDescriptor
 from netman.core.objects.switch_transactional import transactional, \
@@ -28,6 +27,7 @@ class SwitchTransactionalTest(TestCase):
     def setUp(self):
         self.switch_impl = flexmock()
         self.switch_impl.switch_descriptor = SwitchDescriptor(model='', hostname='')
+        self.switch_impl.logger = logging.getLogger()
         self.lock = flexmock()
         self.switch = SwitchTransactional(self.switch_impl, self.lock)
 

--- a/tests/core/switch_factory_test.py
+++ b/tests/core/switch_factory_test.py
@@ -16,8 +16,7 @@ import unittest
 
 from hamcrest import assert_that, equal_to, instance_of, is_, is_not
 import mock
-
-from netman.adapters.switches import cisco, brocade, juniper, dell, dell10g
+from netman.adapters.switches import cisco, juniper, dell, dell10g, brocade_factory
 from netman.core.objects.switch_base import SwitchBase
 from netman.adapters.switches.remote import RemoteSwitch
 from netman.core.objects.switch_descriptor import SwitchDescriptor
@@ -52,7 +51,7 @@ class SwitchFactoryTest(unittest.TestCase):
 
         assert_that(self.factory.factories, is_({
             "cisco": cisco.factory,
-            "brocade": brocade.factory,
+            "brocade": brocade_factory,
             "juniper": juniper.standard_factory,
             "juniper_qfx_copper": juniper.qfx_copper_factory,
             "dell": dell.factory_ssh,


### PR DESCRIPTION
A backward compatibility layer has been added to support calling without the word ethernet
Moved the brocade factory to the switches module, this might become the facade that defines all Classes, it needed to move there for circular dependencies issue
Same issue had me move util stuff to an util module