### PR TITLE
Removed universal from wheels params

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,9 +24,6 @@ packages =
 no-path-adjustment = 1
 logging-level = DEBUG
 
-[wheel]
-universal = 1
-
 [build_sphinx]
 all_files = 1
 build-dir = netman/api/doc_generated


### PR DESCRIPTION
This says we support python 3, which is not yet the case