### PR TITLE
Added get_interfaces compliance test

### DIFF
--- a/netman/adapters/switches/juniper/base.py
+++ b/netman/adapters/switches/juniper/base.py
@@ -113,9 +113,10 @@ class Juniper(SwitchBase):
         config = self.query(all_interfaces, all_vlans)
 
         interface_list = []
-        for if_node in config.xpath("data/configuration/interfaces/interface"):
-            if value_of(if_node.xpath("name")) != "vlan":
-                interface_list.append(self.node_to_interface(if_node, config))
+        for interface_node in config.xpath("data/configuration/interfaces/interface"):
+            interface_name = value_of(interface_node.xpath("name"))
+            if interface_name != "vlan" and not interface_name.startswith("ae"):
+                interface_list.append(self.node_to_interface(interface_node, config))
 
         return interface_list
 

--- a/tests/adapters/compliance_tests/__init__.py
+++ b/tests/adapters/compliance_tests/__init__.py
@@ -15,6 +15,7 @@
 
 from unittest import SkipTest
 
+from tests.adapters.compliance_tests.get_interfaces_test import GetInterfacesTest
 from tests.adapters.compliance_tests.add_vlan_test import AddVlanTest
 from tests.adapters.model_list import available_models
 from tests.adapters.compliance_tests.get_vlan_test import GetVlanTest
@@ -22,6 +23,7 @@ from tests.adapters.compliance_tests.get_vlan_test import GetVlanTest
 _test_classes = [
     GetVlanTest,
     AddVlanTest,
+    GetInterfacesTest
 ]
 
 # compliance rule of thumb:

--- a/tests/adapters/compliance_tests/get_interfaces_test.py
+++ b/tests/adapters/compliance_tests/get_interfaces_test.py
@@ -1,0 +1,49 @@
+# Copyright 2015 Internap.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from hamcrest import assert_that, is_
+from netaddr import IPNetwork
+
+from tests.adapters.configured_test_case import ConfiguredTestCase
+
+
+class GetInterfacesTest(ConfiguredTestCase):
+    _dev_sample = "juniper"
+
+    def test_lists_all_physical_interfaces(self):
+
+        interfaces = self.client.get_interfaces()
+
+        assert_that([i.name for i in interfaces], is_([p.name for p in self.test_ports]))
+
+    def test_does_not_list_bonds(self):
+        self.try_to.add_bond(1)
+
+        interfaces = self.client.get_interfaces()
+
+        assert_that([i.name for i in interfaces], is_([p.name for p in self.test_ports]))
+
+    def test_does_not_list_interface_vlans(self):
+        self.client.add_vlan(1000)
+        self.try_to.add_ip_to_vlan(1000, IPNetwork("1.1.1.1/27"))
+
+        interfaces = self.client.get_interfaces()
+
+        assert_that([i.name for i in interfaces], is_([p.name for p in self.test_ports]))
+
+    def tearDown(self):
+        self.janitor.remove_bond(1)
+        self.janitor.remove_vlan(1000)
+        super(GetInterfacesTest, self).tearDown()
+

--- a/tests/adapters/configured_test_case.py
+++ b/tests/adapters/configured_test_case.py
@@ -73,6 +73,7 @@ class ConfiguredTestCase(unittest.TestCase):
         self.switch_username = specs["username"]
         self.switch_password = specs["password"]
         self.test_port = specs["test_port_name"]
+        self.test_ports = specs["ports"]
         self.test_vrrp_track_id = specs.get("test_vrrp_track_id")
 
         self.remote_switch = RemoteSwitch(SwitchDescriptor(
@@ -82,7 +83,7 @@ class ConfiguredTestCase(unittest.TestCase):
 
         self.client = ValidatingCachedSwitch(self.remote_switch)
         self.try_to = ExceptionIgnoringProxy(self.client, [NotImplementedError])
-        self.janitor = ExceptionIgnoringProxy(self.client, [NetmanException])
+        self.janitor = ExceptionIgnoringProxy(self.client, [NotImplementedError, NetmanException])
 
         self.client.connect()
         self.client.start_transaction()

--- a/tests/adapters/model_list.py
+++ b/tests/adapters/model_list.py
@@ -102,9 +102,9 @@ available_models = [
         "ports": [
             Port("ethernet 1/g1"),
             Port("ethernet 1/g2"),
+            Port("ethernet 1/xg1"),
             Port("ethernet 2/g1"),
             Port("ethernet 2/g2"),
-            Port("ethernet 1/xg1"),
             Port("ethernet 2/xg1")
         ]
     },
@@ -120,9 +120,9 @@ available_models = [
         "ports": [
             Port("ethernet 1/g1"),
             Port("ethernet 1/g2"),
+            Port("ethernet 1/xg1"),
             Port("ethernet 2/g1"),
             Port("ethernet 2/g2"),
-            Port("ethernet 1/xg1"),
             Port("ethernet 2/xg1")
         ]
     },

--- a/tests/adapters/switches/juniper_qfx_copper_test.py
+++ b/tests/adapters/switches/juniper_qfx_copper_test.py
@@ -130,6 +130,21 @@ class JuniperTest(unittest.TestCase):
                   <name>40</name>
                 </unit>
               </interface>
+              <interface>
+                <name>ae10</name>
+                <aggregated-ether-options>
+                  <lacp>
+                    <active/>
+                    <periodic>slow</periodic>
+                  </lacp>
+                </aggregated-ether-options>
+                <unit>
+                  <name>0</name>
+                  <family>
+                    <ethernet-switching />
+                  </family>
+                </unit>
+              </interface>
             </interfaces>
             <vlans/>
         """))

--- a/tests/adapters/switches/juniper_test.py
+++ b/tests/adapters/switches/juniper_test.py
@@ -343,6 +343,21 @@ class JuniperTest(unittest.TestCase):
                   <name>40</name>
                 </unit>
               </interface>
+              <interface>
+                <name>ae10</name>
+                <aggregated-ether-options>
+                  <lacp>
+                    <active/>
+                    <periodic>slow</periodic>
+                  </lacp>
+                </aggregated-ether-options>
+                <unit>
+                  <name>0</name>
+                  <family>
+                    <ethernet-switching />
+                  </family>
+                </unit>
+              </interface>
             </interfaces>
             <vlans/>
         """))


### PR DESCRIPTION
get_interfaces won't return bonds and interface vlans anymore (if it did on a given adapter)