### PR TITLE
Support access/trunk mode and managing native vlan on bond for cisco/dell

### DIFF
--- a/netman/adapters/switches/cisco.py
+++ b/netman/adapters/switches/cisco.py
@@ -291,6 +291,18 @@ class Cisco(SwitchBase):
         with self.config(), self.interface_vlan(vlan_number):
             self.ssh.do("no ip helper-address {}".format(ip_address))
 
+    def set_bond_trunk_mode(self, number):
+        try:
+            return self.set_trunk_mode(bond_name(number))
+        except UnknownInterface:
+            raise UnknownBond(number)
+
+    def set_bond_access_mode(self, number):
+        try:
+            return self.set_access_mode(bond_name(number))
+        except UnknownInterface:
+            raise UnknownBond(number)
+
     def add_bond_trunk_vlan(self, number, vlan):
         try:
             return self.add_trunk_vlan(bond_name(number), vlan)
@@ -300,6 +312,18 @@ class Cisco(SwitchBase):
     def remove_bond_trunk_vlan(self, number, vlan):
         try:
             return self.remove_trunk_vlan(bond_name(number), vlan)
+        except UnknownInterface:
+            raise UnknownBond(number)
+
+    def configure_bond_native_vlan(self, number, vlan):
+        try:
+            return self.configure_native_vlan(bond_name(number), vlan)
+        except UnknownInterface:
+            raise UnknownBond(number)
+
+    def remove_bond_native_vlan(self, number):
+        try:
+            return self.remove_native_vlan(bond_name(number))
         except UnknownInterface:
             raise UnknownBond(number)
 

--- a/netman/adapters/switches/dell.py
+++ b/netman/adapters/switches/dell.py
@@ -27,6 +27,9 @@ from netman.core.objects.exceptions import UnknownInterface, BadVlanName, \
 from netman.core.objects.switch_base import SwitchBase
 
 
+__all__ = ['factory_ssh', 'factory_telnet', 'Dell']
+
+
 def factory_ssh(switch_descriptor, lock):
     return SwitchTransactional(
         impl=Dell(switch_descriptor=switch_descriptor, shell_factory=SshClient),
@@ -39,10 +42,6 @@ def factory_telnet(switch_descriptor, lock):
         impl=Dell(switch_descriptor=switch_descriptor, shell_factory=TelnetClient),
         lock=lock,
     )
-
-
-def bond_name(number):
-    return "port-channel {}".format(number)
 
 
 class Dell(SwitchBase):
@@ -219,46 +218,32 @@ class Dell(SwitchBase):
             self.set("{}lldp med transmit-tlv network-policy", "" if enabled else "no ")
 
     def set_bond_description(self, number, description):
-        try:
-            return self.set_interface_description(bond_name(number), description)
-        except UnknownInterface:
-            raise UnknownBond(number)
+        with NamedBond(number) as bond:
+            return self.set_interface_description(bond.name, description)
 
     def set_bond_trunk_mode(self, number):
-        try:
-            return self.set_trunk_mode(bond_name(number))
-        except UnknownInterface:
-            raise UnknownBond(number)
+        with NamedBond(number) as bond:
+            return self.set_trunk_mode(bond.name)
 
     def set_bond_access_mode(self, number):
-        try:
-            return self.set_access_mode(bond_name(number))
-        except UnknownInterface:
-            raise UnknownBond(number)
+        with NamedBond(number) as bond:
+            return self.set_access_mode(bond.name)
 
     def add_bond_trunk_vlan(self, number, vlan):
-        try:
-            return self.add_trunk_vlan(bond_name(number), vlan)
-        except UnknownInterface:
-            raise UnknownBond(number)
+        with NamedBond(number) as bond:
+            return self.add_trunk_vlan(bond.name, vlan)
 
     def remove_bond_trunk_vlan(self, number, vlan):
-        try:
-            return self.remove_trunk_vlan(bond_name(number), vlan)
-        except UnknownInterface:
-            raise UnknownBond(number)
+        with NamedBond(number) as bond:
+            return self.remove_trunk_vlan(bond.name, vlan)
 
     def configure_bond_native_vlan(self, number, vlan):
-        try:
-            return self.configure_native_vlan(bond_name(number), vlan)
-        except UnknownInterface:
-            raise UnknownBond(number)
+        with NamedBond(number) as bond:
+            return self.configure_native_vlan(bond.name, vlan)
 
     def remove_bond_native_vlan(self, number):
-        try:
-            return self.remove_native_vlan(bond_name(number))
-        except UnknownInterface:
-            raise UnknownBond(number)
+        with NamedBond(number) as bond:
+            return self.remove_native_vlan(bond.name)
 
     def config(self):
         return SubShell(self.shell, enter="configure", exit_cmd='exit')
@@ -349,3 +334,23 @@ def resolve_trunk_vlans(interface_data):
         if regex.match("switchport \S+ allowed vlan add (\S+)", line):
             return parse_vlan_ranges(regex[0])
     return []
+
+
+def bond_name(number):
+    return "port-channel {}".format(number)
+
+
+class NamedBond(object):
+    def __init__(self, number):
+        self.number = number
+
+    @property
+    def name(self):
+        return bond_name(self.number)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if exc_type is UnknownInterface:
+            raise UnknownBond(self.number), None, exc_tb

--- a/netman/adapters/switches/dell.py
+++ b/netman/adapters/switches/dell.py
@@ -218,6 +218,24 @@ class Dell(SwitchBase):
             self.set("{}lldp med transmit-tlv capabilities", "" if enabled else "no ")
             self.set("{}lldp med transmit-tlv network-policy", "" if enabled else "no ")
 
+    def set_bond_description(self, number, description):
+        try:
+            return self.set_interface_description(bond_name(number), description)
+        except UnknownInterface:
+            raise UnknownBond(number)
+
+    def set_bond_trunk_mode(self, number):
+        try:
+            return self.set_trunk_mode(bond_name(number))
+        except UnknownInterface:
+            raise UnknownBond(number)
+
+    def set_bond_access_mode(self, number):
+        try:
+            return self.set_access_mode(bond_name(number))
+        except UnknownInterface:
+            raise UnknownBond(number)
+
     def add_bond_trunk_vlan(self, number, vlan):
         try:
             return self.add_trunk_vlan(bond_name(number), vlan)
@@ -227,6 +245,18 @@ class Dell(SwitchBase):
     def remove_bond_trunk_vlan(self, number, vlan):
         try:
             return self.remove_trunk_vlan(bond_name(number), vlan)
+        except UnknownInterface:
+            raise UnknownBond(number)
+
+    def configure_bond_native_vlan(self, number, vlan):
+        try:
+            return self.configure_native_vlan(bond_name(number), vlan)
+        except UnknownInterface:
+            raise UnknownBond(number)
+
+    def remove_bond_native_vlan(self, number):
+        try:
+            return self.remove_native_vlan(bond_name(number))
         except UnknownInterface:
             raise UnknownBond(number)
 


### PR DESCRIPTION
This is a partial improvement that only allow adding/removing native vlan and changing access/trunk mode on bonds.  It does not support listing or creating or deleting bonds.